### PR TITLE
docs: loyalty platform market research, TRD v2, and per-phase PRDs

### DIFF
--- a/docs/loyalty-platform-market-research.md
+++ b/docs/loyalty-platform-market-research.md
@@ -1,0 +1,499 @@
+# Loyalty & Rewards Platform — Market Research Report
+> Researcher: Claude (AI Agent) — Senior Product Researcher persona
+> Date: 2026-06-24
+> Version: 1.0
+
+> **Sourcing note.** Pricing and platform-capability claims below were spot-checked against vendor sites and third-party review aggregators (G2, Capterra, GetApp) in June 2026. Where a claim was **not** verified against a primary source, it is tagged **(AI synthesis — verify before publishing)**. Pricing changes quarterly — re-verify before any external use. Comparison-matrix cells use ❓ wherever a capability could not be confirmed from public documentation.
+
+---
+
+## DOCUMENT A: Market Landscape Overview
+
+### A1. What Is a Modern Loyalty Platform?
+
+A loyalty platform is the software that runs a rewards program: it tracks who your customers are, what they do, how many points they have, and what they can get in return. Twenty years ago this was a punch card or a plastic card with a barcode, backed by a simple database that added points overnight in a batch job. Rules were fixed ("1 point per dollar, 500 points = $5 off"), the same for everyone, and changing them meant a developer ticket and a release.
+
+Today's platforms are **API-first** (other systems talk to them through a standard web interface), **event-driven** (they react to a customer action — a purchase, an app open, a review — in milliseconds rather than overnight), and **behavior-driven** (rewards respond to what a person actually does, not just how much they spend). The points engine is increasingly **headless** — the rules and balances live in the platform, but the brand builds its own customer-facing screens on top. This lets a marketer launch a "triple points this weekend on sneakers" campaign through a visual editor, with no engineering involved, and have it live in minutes.
+
+The leading edge in **2025–2026 is AI and personalization**. Vendors now market "AI loyalty" as the headline: predicting which customers are about to churn and auto-triggering a retention offer, recommending the single best reward for each person at the right moment, and using conversational AI agents to help marketers design programs (Antavo's "Timi AI," Loyalty Juggernaut's "Agentic AI Compass," Hologrow's intent-detection engine). The market direction is clear: away from one-size-fits-all point tables, toward real-time, individualized, predictive engagement — with a parallel rise in *composable* approaches where brands assemble a program from best-of-breed parts rather than buying one monolith.
+
+### A2. Market Segmentation
+
+| Segment | Description | Best For | Example Platforms |
+|---|---|---|---|
+| Enterprise Suite | Full-featured, complex rule engines, multi-market, partner ecosystems | Large retail, airline, bank | Antavo, Annex Cloud, Loyalty Juggernaut |
+| Composable / API-first | Headless, developer-driven, highly flexible incentive engines | Tech-forward brands | Talon.One, Voucherify |
+| SMB / Plug-and-play | Quick setup, Shopify/WooCommerce native | Small e-commerce | Smile.io, LoyaltyLion, Yotpo |
+| Vertical-specific | Built for one industry's nuances | F&B/QSR, hospitality, B2B | Punchh (QSR), Tango (B2B incentives), Clutch (retail) |
+| Open-source | Self-hosted, customizable, no licensing fee for core | Teams with dev capacity | Open Loyalty |
+| AI-native (emerging) | Intent-driven personalization, predictive rewards | Innovation-led brands | Hologrow, Loyalty Juggernaut (GRAVTY) |
+
+### A3. Architecture Paradigms
+
+- **Traditional (monolithic).** One large, tightly-coupled system handling rules, balances, UI, and reporting together, often updating points in nightly batches. Reliable but rigid: any change touches the whole system, customer feedback is delayed (you earned points yesterday, you see them today), and scaling one part means scaling all of it.
+
+- **MACH** (Microservices, API-first, Cloud-native, Headless). The platform is split into small independent services (microservices), every function is reachable through a documented API, it runs on elastic cloud infrastructure, and the logic is decoupled from any specific frontend (headless). The payoff: you can change or scale one piece without touching the rest, and ship faster.
+
+- **Composable Commerce.** Rather than buying one suite that does everything adequately, you assemble best-of-breed components — a points engine here, a voucher engine there, your own CDP and email tool — connected by APIs. More flexibility and less vendor lock-in, at the cost of needing engineering capacity to integrate and maintain the seams.
+
+- **Event-Driven / Real-time.** The system listens to a stream of events (purchase made, profile completed, cart abandoned) and reacts instantly — awarding points, firing a webhook, triggering an offer. This is what makes "you just earned 340 points" appear in the app within seconds and enables behavioral triggers that feel responsive rather than delayed.
+
+---
+
+## DOCUMENT B: Feature Catalogue
+
+### B1. Core Feature Taxonomy
+
+> The "Who Offers It" column reflects the *typical* tier where a feature is found, synthesized from vendor documentation and review sites. Treat as a general guide, not a per-vendor guarantee. **(Partial AI synthesis — verify per vendor before publishing.)**
+
+#### B1.1 Points & Currency Management
+| Feature | Description | Who Offers It |
+|---|---|---|
+| Multi-currency points | Run separate point types (base, bonus, tier points) simultaneously | Enterprise, Composable |
+| Points expiry rules | Configurable expiry: rolling, fixed date, activity-based | All tiers |
+| Points transfer | Members gift or pool points | Enterprise |
+| Currency conversion | Exchange points for cash value, miles, crypto | Enterprise, Emerging |
+| Soft currency | Non-redeemable engagement credits ("stars" for status only) | Enterprise |
+| Points bank ledger | Full audit trail of every earn/burn transaction | Enterprise, Composable |
+
+#### B1.2 Earning Mechanics
+| Feature | Description | Who Offers It |
+|---|---|---|
+| Transactional earning | Points per purchase (flat or tiered by amount) | All |
+| Behavioral earning | Points for reviews, referrals, social shares, app opens | Enterprise, Composable |
+| Partner earning | Earn at partner brands (co-branded) | Enterprise |
+| Event-triggered earning | Custom events via API (profile completion, video watched) | Composable |
+| Bonus multipliers | 2x/3x during campaigns, on SKUs, or for tiers | All |
+| Retroactive earning | Award points for past purchases after joining | Enterprise |
+| Offsite earning | Points for purchases outside brand's own channels | Enterprise |
+
+#### B1.3 Redemption Mechanics
+| Feature | Description | Who Offers It |
+|---|---|---|
+| Discount redemption | Points off at checkout (fixed or %) | All |
+| Free product redemption | Points exchanged for specific SKUs / catalog items | All |
+| Voucher / coupon redemption | Points converted to single-use codes | Composable, Enterprise |
+| Cashback redemption | Points paid to a payment method | Enterprise |
+| Charity / donation | Redeem to donate to causes | Enterprise, Composable |
+| Experiential rewards | Redeem for events, experiences, exclusive access | Enterprise |
+| Pay-with-points (PwP) | Partial redemption at checkout (200 pts = $2 off) | All |
+| Tiered reward catalog | Rewards unlocked by tier level | Enterprise |
+
+#### B1.4 Tiers & Status
+| Feature | Description | Who Offers It |
+|---|---|---|
+| Threshold-based tiers | Qualify by spend, points, or visits in a period | All |
+| Lifetime tiers | Permanent tier on cumulative lifetime value | Enterprise |
+| Tier downgrade rules | Configurable grace periods and qualifying windows | Enterprise, Composable |
+| Tier benefits | Exclusive perks, multipliers, early access by tier | All |
+| Soft tier qualification | Temporary tier access before full qualification | Enterprise |
+| Tier challenges | Accelerated paths to next tier via challenges | Enterprise |
+
+#### B1.5 Vouchers & Promotions
+| Feature | Description | Who Offers It |
+|---|---|---|
+| Bulk voucher generation | Thousands of unique codes in one action | Composable, Enterprise |
+| Voucher stacking rules | Control which vouchers combine | Composable, Enterprise |
+| Contextual eligibility | Valid only for specific SKUs, categories, users, channels | All |
+| Referral vouchers | Auto-generated unique codes per referrer | All |
+| Welcome / birthday offers | Triggered vouchers on lifecycle events | All |
+| Dynamic value vouchers | Value calculated at redemption based on cart/context | Composable |
+| Influencer / partner codes | Trackable promo codes for external partners | Composable, Enterprise |
+
+#### B1.6 Gamification
+| Feature | Description | Who Offers It |
+|---|---|---|
+| Challenges & missions | Multi-step tasks that unlock rewards | Enterprise, Composable |
+| Streaks | Bonus rewards for consecutive activity | Emerging, Enterprise |
+| Badges & achievements | Non-monetary recognition for milestones | Enterprise, Composable |
+| Leaderboards | Competitive ranking within a program | Emerging, Enterprise |
+| Spin-the-wheel / scratch cards | Randomized reward moments | Enterprise |
+| Progress bars | Visual progress toward next reward/tier | All (UI layer) |
+
+#### B1.7 Personalization & AI
+| Feature | Description | Who Offers It |
+|---|---|---|
+| Segment-based offers | Different rules per audience segment | Enterprise, Composable |
+| Predictive churn offers | AI flags at-risk members, auto-triggers retention | Enterprise, Emerging |
+| Next-best-offer | AI recommends the most relevant reward at the right moment | Emerging, Enterprise |
+| Behavioral triggers | Rules fired by user-behavior events in real time | Composable, Enterprise |
+| A/B testing | Test reward values/mechanics on subsets | Composable, Enterprise |
+| Dynamic personalization | Reward values/types change per individual | Emerging |
+
+#### B1.8 Partner & Coalition Programs
+| Feature | Description | Who Offers It |
+|---|---|---|
+| Multi-brand earning | Earn across a network of brands | Enterprise |
+| Partner dashboard | Separate admin views for coalition partners | Enterprise |
+| Revenue sharing | Automated settlement between partners | Enterprise |
+| White-label member portal | Each brand keeps its own branded experience | Enterprise |
+
+#### B1.9 Analytics & Reporting
+| Feature | Description | Who Offers It |
+|---|---|---|
+| Member lifecycle reports | Acquisition → activation → retention → churn funnel | Enterprise, Composable |
+| Earn/burn ratio | Liability-vs-engagement health metric | Enterprise |
+| Campaign performance | ROI of individual promotions and challenges | All |
+| Cohort analysis | How member groups behave over time | Enterprise |
+| CLV modeling | Predictive value per member | Enterprise, Emerging |
+| Real-time dashboards | Live views of active campaigns and redemptions | Enterprise, Composable |
+| Export / BI integration | Export to Snowflake, BigQuery, Tableau | Enterprise, Composable |
+
+---
+
+## DOCUMENT C: Platform Comparison Matrix
+
+✅ full · ⚠️ partial/limited · ❌ not available · ❓ unverified
+
+### C1. Feature Coverage by Platform
+
+> Cells reflect public documentation and review-site evidence as of June 2026. ❓ = not confirmable from public sources. **(Partial AI synthesis — verify before publishing.)**
+
+| Feature Area | Talon.One | Antavo | Voucherify | Open Loyalty | Smile.io | Punchh | Hologrow |
+|---|---|---|---|---|---|---|---|
+| Multi-currency points | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ❓ |
+| Event-triggered earning | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ✅ |
+| Voucher engine | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ⚠️ |
+| Tier management | ⚠️ | ✅ | ⚠️ | ✅ | ✅ | ✅ | ❓ |
+| AI personalization | ⚠️ | ✅ | ⚠️ | ⚠️ | ❌ | ✅ | ✅ |
+| Gamification | ⚠️ | ✅ | ⚠️ | ✅ | ⚠️ | ✅ | ⚠️ |
+| Partner / coalition | ⚠️ | ✅ | ⚠️ | ✅ | ❌ | ⚠️ | ❓ |
+| Real-time rules engine | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ✅ |
+| Headless / API-first | ✅ | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ |
+| Open-source / self-host | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Native mobile SDK | ⚠️ | ✅ | ⚠️ | ⚠️ | ⚠️ | ✅ | ❓ |
+| BI / data export | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ❓ |
+
+Notes:
+- **Talon.One** is an incentives/promotion engine first; tiers and loyalty constructs are supported but it is most differentiated on its rules engine and campaign logic. Loyalty-program features expanded over recent releases.
+- **Smile.io** is deliberately SMB/Shopify-focused; API access and advanced features are gated to the Enterprise plan.
+- **Punchh (PAR)** is QSR/restaurant-specialized; "headless" is partial because it is sold as an integrated guest-engagement suite rather than a pure API product.
+- **Hologrow** is early-stage and AI-native; several enterprise constructs are unverified from public docs (hence ❓).
+
+### C2. Pricing Model Comparison
+
+> Verified June 2026 against vendor pricing pages and review aggregators. Prices change quarterly — re-verify.
+
+| Platform | Model | Entry Price (approx.) | Pricing Drivers | Notes |
+|---|---|---|---|---|
+| Talon.One | Usage-based, custom | Custom (enterprise; no public list price — reports of ~$1,500/mo basic, unconfirmed) | Data volume, active members, API usage | Demo required; all plans unlock full product. **(Entry price ❓ — not officially published.)** |
+| Antavo | Contract / enterprise | Custom | Members, markets | Annual commitment; no public pricing |
+| Voucherify | Tiered SaaS + free | Free ($0) → Startup $170/mo → Growth $399/mo → Professional $599/mo → Enterprise custom | API calls/month, projects | Transparent public pricing; 60-day trial |
+| Smile.io | Tiered SaaS + free | Free → Starter $49/mo → Growth $199/mo → Pro $599/mo → Enterprise from ~$1k/mo | Plan tier; API access only on Enterprise | Shopify-native; VIP tiers on Pro+ |
+| Open Loyalty | Open-source + paid support | Self-hosted core free | Dev effort + hosting; enterprise license/support add-on | Full control, needs engineering capacity |
+| Punchh (PAR) | Custom | Custom | Locations, members | Restaurant/QSR-focused; quote-based |
+| Loyalty Juggernaut (GRAVTY) | Enterprise / cloud | Custom (also AWS Marketplace) | Members, transactions, modules | Serverless, high-TPS; SOC/ISO certified |
+| Hologrow | SaaS (AI-native) | Public pricing not confirmed | Likely usage/members | Early-stage; verify in demo. **(❓)** |
+
+### C3. Integration Ecosystem
+
+> Synthesized from vendor integration docs/listings as of June 2026. Confirm specific connectors in a demo. **(Partial AI synthesis.)**
+
+| Platform | Native E-commerce | CRM | CDP | ESP (Email) | POS | Mobile |
+|---|---|---|---|---|---|---|
+| Talon.One | Shopify, Magento, SAP (via API/connectors) | Salesforce, HubSpot | Segment | Klaviyo, Braze | Via API | SDK / API |
+| Antavo | Via API + connectors | Salesforce | Segment, mParticle | Braze, Klaviyo | Multiple | Native iOS/Android SDK |
+| Voucherify | Shopify, WooCommerce | Salesforce, HubSpot | Segment | Klaviyo, Mailchimp, Braze | Via webhook/API | SDK |
+| Open Loyalty | Via API/webhooks (commercetools accelerator) | Via API | Via API | Via API | Via API | SDK / via API |
+| Smile.io | Shopify, BigCommerce, Wix | ❓ (limited) | ❓ | Klaviyo, Mailchimp | ❌ (online-first) | ⚠️ (web widget; no full native SDK) |
+| Punchh (PAR) | PAR Ordering, first-party channels | PAR ecosystem | ❓ | Email/SMS built-in | Deep POS (PAR + 3rd party) | Native app + Apple/Google Wallet (Smart Passes) |
+| Hologrow | Shopify + e-commerce (per docs) | ❓ | ❓ | ❓ | ❓ | ❓ |
+
+---
+
+## DOCUMENT D: UX / UI Analysis
+
+### D1. Member-Facing Experience Patterns
+
+#### The Enrollment Journey
+- **Entry points.** Best programs enroll at the highest-intent moment: at checkout ("Create an account to earn 340 points on this order"), post-purchase confirmation, in-app onboarding, and in-store via QR/staff prompt. Multiple entry points beat a single "join" page.
+- **Friction reduction.** Social/SSO login, one-tap enrollment for existing customers, and *progressive profiling* (collect name + email now, birthday and preferences later) instead of a long upfront form.
+- **The "welcome moment."** Top programs deliver value within seconds: instant welcome bonus points, a first-order voucher, or immediate tier status. Seeing a non-zero balance on day one drives activation.
+- **Mobile vs. web parity.** Members expect identical balance, history, and redemption on web and app. Forcing an app download to participate is an anti-pattern (see D5).
+
+#### The Rewards Discovery Experience
+- **Catalog UX.** Card grid with image, name, point cost, and a clear CTA; filter/sort by category, point cost, and affordability ("show what I can afford now").
+- **Contextual surfacing.** Show the relevant reward at the relevant moment — "You're 60 points from a free coffee" on the cart page, not buried in a rewards tab.
+- **Transparency.** Always show point value in real money ("500 pts = $5"). Hidden value erodes trust.
+- **Empty states.** Before a member can afford anything, show *progress and a path*: "Earn 160 more points to unlock your first reward," plus easy earn actions — not a blank "no rewards available."
+
+#### The Redemption Flow
+1. **Trigger.** Member sees a reward they can afford, clearly marked as redeemable now.
+2. **Selection.** Crystal-clear "you get X, it costs Y points," remaining balance shown.
+3. **Confirmation.** A deliberate confirm step before committing points (prevents accidental spend).
+4. **Delivery.** Instant for digital (code/voucher applied immediately); clear ETA for physical/experiential.
+5. **Payoff.** Receipt + updated balance + an emotional moment (animation, "Enjoy!", celebratory toast). The dopamine hit drives repeat engagement.
+
+#### The Member Dashboard / Profile
+Gold-standard dashboard includes:
+- Point balance — **current, pending, and expiring soon** (three distinct numbers).
+- Tier status + visual progress to next tier.
+- Transaction history (earn and burn, chronological, with icons).
+- Active vouchers with expiry dates.
+- Personalized offers tailored to the member.
+- Referral mechanism (share link + tracking).
+
+### D2. Merchant / Admin Console UX Patterns
+
+| Admin Feature | UX Best Practice | Common Pain Points |
+|---|---|---|
+| Rule builder | Visual, no-code condition→action builder | Complex logic chains become unmaintainable; hard to debug "why did this fire?" |
+| Campaign creation | Template library + guided wizard | Blank-canvas fatigue; no guardrails against costly misconfig (e.g. stackable 100% discount) |
+| Member search & lookup | Instant full-text search + filters | Slow queries on large member bases |
+| Fraud dashboard | Real-time alerts + manual override | Alert fatigue from poorly-tuned thresholds |
+| Reporting | Scheduled exports + live dashboards | BI integration friction, data latency |
+| Voucher management | Bulk import/export, status at a glance | No audit trail for manual edits |
+
+### D3. UI Component Inventory (Common Patterns)
+
+**Member-facing components**
+- Point balance widget (persistent header/nav display)
+- Tier progress bar (horizontal or circular indicator)
+- Reward card (image, name, point cost, CTA)
+- Voucher tile (code, value, expiry, copy-to-clipboard)
+- Activity feed / transaction history (chronological list with icons)
+- Challenge card (title, progress, deadline, completion reward)
+- Referral share widget (unique link, social buttons, tracking)
+- Notification toast (points earned, reward unlocked, tier upgrade)
+
+**Admin-facing components**
+- Rule builder canvas (condition → action flow)
+- Cohort selector (segment picker with live member-count preview)
+- Campaign scheduler (calendar picker + recurrence config)
+- Voucher batch generator (CSV import / quantity selector)
+- Analytics card grid (earn rate, redemption rate, active members, churn)
+- Member profile drawer (slide-in panel with full history)
+
+### D4. Mobile Experience Patterns
+
+| Pattern | Description | Why It Matters |
+|---|---|---|
+| Persistent balance display | Points always visible in app header | Constant value reminder; drives engagement |
+| Push notifications | Alerts for points earned, offers expiring | Re-engagement without opening the app |
+| Wallet integration | Apple Wallet / Google Wallet membership cards (e.g. Punchh Smart Passes) | Frictionless in-store identification |
+| Offline earning | QR / NFC scan at POS without live internet | Critical for physical retail |
+| Biometric auth | Face/fingerprint login | Removes friction for high-frequency users |
+
+### D5. UX Anti-Patterns to Avoid
+
+| Anti-Pattern | Why It's Harmful | Better Alternative |
+|---|---|---|
+| Hidden point value | Members don't know what a point is worth | Always show cash equivalent |
+| Expiry without warning | Points vanish silently → anger, churn | 30/14/7-day email + in-app alerts |
+| Redemption minimums too high | "10,000 points to redeem" feels unreachable | Minimum ≤ ~1 meaningful earn session |
+| Over-complicated tier rules | Multiple qualifying criteria confuse members | One primary qualifying metric per tier |
+| Reward catalog mismatch | Rewards don't fit brand or member taste | Audit catalog against actual redemption data |
+| Forced app download | Web-only members locked out | Always offer a web fallback |
+| Opaque fraud blocks | Account frozen with no explanation | Transparent messaging + human appeal path |
+
+---
+
+## DOCUMENT E: Use Case Stories
+
+### E1. Retail / E-commerce Loyalty
+**User Story.** As an online fashion shopper, I want to earn and redeem points seamlessly across purchases and returns, so I feel rewarded without administrative friction.
+
+**Best-Practice Flow.**
+1. Member sees balance in cart: "You'll earn 340 pts on this order."
+2. Purchase → points awarded instantly, visible in app within seconds.
+3. Return processed → points deducted cleanly with a clear notification.
+4. 7 days later: "You're 160 pts from Gold tier" nudge email.
+5. Member redeems for $10 off at next checkout — no support call.
+
+**What separates great programs.** Real-time balance visibility, clean returns handling (no negative-balance surprises), proactive tier-progress nudges.
+
+### E2. QSR / F&B (Quick Service Restaurant)
+**User Story.** As a coffee shop regular, I want a free drink after every 10 visits, tracked on my phone, and to pay faster without fumbling for a card.
+
+**Best-Practice Flow.**
+1. App home screen shows current "star" count.
+2. Member orders → scans QR at counter or pays in-app.
+3. Stars awarded immediately; progress bar animates.
+4. At 10 stars: push "Your free drink is ready!" with one-tap redeem.
+5. Barista sees redemption on POS — no paper coupon.
+
+**Differentiators.** Scan-and-pay removes friction; instant visual feedback builds habit. Wallet-based passes (e.g. PAR Punchh Smart Passes) skip the app entirely for identification.
+
+### E3. B2B / Channel Partner Incentives
+**User Story.** As a reseller rep, I want bonus rewards for hitting quarterly sales targets, so I prioritize this vendor's products.
+
+**Best-Practice Flow.**
+1. Rep logs into partner portal, sees quarter progress vs. target.
+2. Qualifying sales uploaded via API from CRM; points awarded weekly.
+3. Target hit → email + portal notification with reward catalog link.
+4. Rep picks reward (gift card, travel, merchandise) from a curated catalog.
+5. Fulfilled within 5 business days; confirmation + tracking email.
+
+**Differentiators.** Transparent progress visibility, fast fulfillment, tax-compliant reward delivery (1099/local-tax handling). Platforms like Tango specialize in B2B reward fulfillment.
+
+### E4. Travel & Hospitality
+**User Story.** As a frequent business traveler, I want hotel stays, restaurant bills, and spa visits to earn the same points, redeemable for free nights without blackout dates.
+
+**Best-Practice Flow.**
+1. Member checks in via app (room key on phone); stay auto-attributed.
+2. All on-property spend (F&B, spa, minibar) earns points via POS integration.
+3. Mid-stay: dashboard shows points earned so far.
+4. Points redeemable against real-time inventory — no blackouts.
+5. Checkout email: points earned, balance, next-tier progress.
+
+**Differentiators.** Unified property-spend earning, no blackout dates, mobile-first check-in/out.
+
+### E5. Coalition / Multi-Brand Program
+**User Story.** As a supermarket loyalty member, I want to earn at grocery, pharmacy, and fuel — and redeem across all three — with one card and one balance.
+
+**Best-Practice Flow.**
+1. One app QR works at any partner (grocery, pharmacy, fuel).
+2. Points earned per partner's rules, pooled into one universal balance.
+3. Redeem fuel points at the pump via loyalty number.
+4. Monthly statement shows earn breakdown by partner.
+5. Partners share member data only at aggregate level (privacy preserved).
+
+**Differentiators.** Single identity across partners, cross-category redemption, privacy-preserving architecture, automated inter-partner settlement.
+
+---
+
+## DOCUMENT F: Technical Capabilities Reference
+
+### F1. Core Engine Capabilities
+
+| Capability | Plain Language | Why It Matters for Product |
+|---|---|---|
+| Rule engine | Configurable "if this, then that" for every earn/burn decision | Complex campaigns without code changes |
+| Event streaming | Reacts to actions in milliseconds, not nightly batches | Real-time awards and instant feedback |
+| Idempotency | Safely handles duplicate requests (double-tap, retry) | Members don't earn twice on one purchase |
+| Webhooks | Instant outbound notifications when something happens | Braze/Klaviyo send "you earned points!" in real time |
+| API rate limits | How many transactions/second the platform handles | Determines survival of your peak sale day |
+| Multi-tenancy | One platform instance runs multiple brands/regions | Essential for enterprise/regional programs |
+
+> **Benchmark reference.** Loyalty Juggernaut's GRAVTY publicly claims >100M transactions/hour (~30,000 TPS) at <50ms average latency — a useful high-end yardstick when scoring "real-time rules engine" claims.
+
+### F2. Data Architecture Patterns
+
+| Pattern | What It Means | Best Used When |
+|---|---|---|
+| Event sourcing | Every transaction stored as an immutable event log | Audit, dispute resolution, retroactive recalculation |
+| CQRS | Separate write (transactions) and read (dashboards) systems | High-volume programs where read performance matters |
+| CDC (Change Data Capture) | DB changes streamed to other systems automatically | Keep CRM/CDP/analytics in sync without batch ETL |
+| Ledger model | Points as a bank account with double-entry accounting | Programs with financial-liability implications |
+
+> This repo's own architecture (Postgres + Redis + Kafka, repository/service layering) maps to an event-driven + ledger approach: Kafka as the event stream, a points-transaction table as the ledger. Idempotency keys on earn/burn endpoints are the single most important correctness safeguard.
+
+### F3. Integration Patterns
+
+| Integration Type | How It Works | Common Use Cases |
+|---|---|---|
+| REST API | Request-response, real-time earn/burn | POS, checkout, member lookup |
+| Webhooks | Platform pushes events to you | Trigger emails, update CRM, fraud alerts |
+| Event stream (Kafka/SQS) | High-throughput event pipe | Millions of txns/day, real-time analytics |
+| File import/export | Batch CSV/SFTP for legacy systems | ERP sync, offline POS reconciliation |
+| SDK (mobile/web) | Pre-built code to embed loyalty UI | App loyalty tabs, balance display |
+
+### F4. Security & Compliance Considerations
+
+| Area | What to Look For | Red Flags |
+|---|---|---|
+| Points fraud prevention | Velocity checks, device fingerprinting, manual override | No controls or only post-hoc detection |
+| Data privacy (GDPR/PDPA) | Right-to-erasure, consent management, data minimization | PII stored with no clear deletion process |
+| Financial compliance | Breakage accounting, gift-card regs, B2B tax reporting | No audit trail; points treated as pure marketing |
+| SSO / IAM | SAML/OAuth for admin, MFA for members | Shared admin passwords; no MFA |
+| Pen testing / certs | SOC 2, ISO 27001, annual pen test | No certifications; vague security docs |
+
+> Enterprise/AI-native vendors increasingly lead with certifications — e.g. GRAVTY cites ISO 27001/27018, SOC 1 & 2 Type II, GDPR/CCPA. Treat the absence of named certs at enterprise tier as a red flag.
+
+---
+
+## DOCUMENT G: Recommendations & Decision Framework
+
+### G1. Build vs. Buy vs. Compose
+
+| Scenario | Recommended Approach | Rationale |
+|---|---|---|
+| MVP, fast time-to-market, limited budget | Buy (SMB SaaS) | Smile.io / LoyaltyLion / Yotpo — live in days |
+| Complex rules, multiple markets, in-house tech | Compose (API-first) | Talon.One or Voucherify + your own UI |
+| Enterprise, multi-brand, coalition | Buy (Enterprise Suite) | Antavo, Annex Cloud, Loyalty Juggernaut — full partner ecosystem |
+| Full ownership, high volume, data sovereignty | Build on open-source | Open Loyalty as engine + custom frontend |
+| AI-first, personalization-heavy, digital-native | Emerging platforms | Hologrow, LJI — evaluate carefully (maturity varies) |
+
+> **For this team (go-loyalty-point, a Go/Postgres/Redis/Kafka service):** you are already on the *build* path with a composable foundation. The pragmatic question is *what to build vs. integrate* — e.g. build the core ledger + rules in-house (you have the stack), but consider integrating a specialized voucher engine (Voucherify) or fulfillment provider (Tango for B2B) rather than rebuilding those. **(AI synthesis — recommendation, not a verified benchmark.)**
+
+### G2. Platform Selection Scorecard
+
+Weight and score each criterion (1–5) for your context:
+
+| Criterion | Weight | Platform A | Platform B | Platform C |
+|---|---|---|---|---|
+| Feature completeness | 20% | /5 | /5 | /5 |
+| API flexibility | 15% | /5 | /5 | /5 |
+| Time to launch | 15% | /5 | /5 | /5 |
+| Pricing model fit | 15% | /5 | /5 | /5 |
+| Integration ecosystem | 10% | /5 | /5 | /5 |
+| Mobile capability | 10% | /5 | /5 | /5 |
+| Analytics / data ownership | 10% | /5 | /5 | /5 |
+| Vendor stability | 5% | /5 | /5 | /5 |
+| **Weighted total** | 100% | | | |
+
+### G3. Questions to Ask Every Vendor
+
+**Technical**
+- 99th-percentile API response time at peak load?
+- How do you handle double-spend / race conditions in redemptions?
+- Can we access raw event-level data for our own warehouse?
+- Disaster recovery / RTO?
+
+**Commercial**
+- What happens to our data if we churn?
+- Minimum contract term?
+- How are price increases handled at renewal?
+
+**Product**
+- Roadmap for AI/personalization features?
+- How many engineers do customers typically need to integrate?
+- Three reference customers in our industry?
+
+---
+
+## DOCUMENT H: Open Research Questions
+
+- [ ] What loyalty mechanics resonate most with Indonesian / Southeast Asian consumers specifically?
+- [ ] What is the realistic earn/burn liability cost for a new program in our vertical?
+- [ ] Which platforms have succeeded with programs similar to our use case (EV / mobility)?
+- [ ] How do our target members prefer to interact: app, WhatsApp, web, or in-person?
+- [ ] Typical activation rate (% of enrollees who earn at least once) in comparable programs?
+- [ ] What fraud patterns should we design against first?
+
+---
+
+## DOCUMENT I: Glossary of Loyalty Terms
+
+| Term | Plain-Language Definition |
+|---|---|
+| Earn rate | Points per currency unit spent (e.g. 1 pt per $1) |
+| Burn rate | Point cost of a reward (e.g. 500 pts = $5 off) |
+| Breakage | Earned-but-never-redeemed points — a benefit for the operator |
+| Soft currency | Points/credits for status only, no redemption value |
+| Hard currency | Points with real monetary value → financial liability |
+| Tier qualification window | Period to accumulate enough spend/points to reach/keep a tier |
+| Coalition program | Program shared across multiple brands; earn and spend at all partners |
+| Headless loyalty | Loyalty logic decoupled from the frontend — your UI, their engine |
+| Idempotency key | Ensures a transaction can be retried safely without double-awarding |
+| Event-driven | Reacts to real-time signals, not nightly batches |
+| Voucher stacking | Applying multiple codes/offers at once; controlled by stacking rules |
+| Redemption friction | Any barrier to using earned rewards |
+| CLV | Total revenue expected from one customer over the relationship |
+| Churn prediction | ML model identifying members at risk of going inactive |
+| MACH | Microservices, API-first, Cloud-native, Headless |
+
+---
+
+## Sources
+
+- [Talon.One — Pricing](https://www.talon.one/pricing) · [G2](https://www.g2.com/products/talon-one/pricing) · [Capterra](https://www.capterra.com/p/159778/Talon-One/pricing/)
+- [Voucherify — Pricing](https://www.voucherify.io/pricing) · [GetApp](https://www.getapp.com/website-ecommerce-software/a/voucherify/pricing/)
+- [Smile.io — Pricing](https://smile.io/pricing) · [Flowium plan breakdown](https://flowium.com/blog/understanding-the-smile-io-pricing-plans/)
+- [Open Loyalty](https://www.openloyalty.io/) · [Voucherify open-source accelerator](https://www.voucherify.io/open-source-composable-loyalty-accelerator)
+- [Antavo — AI Loyalty Cloud](https://antavo.com/) · [Gartner Peer Insights](https://www.gartner.com/reviews/product/antavo-ai-loyalty-cloud) · [Antavo in Forrester Loyalty Platforms Landscape Q3 2025](https://antavo.com/news/antavo-named-in-the-loyalty-platforms-landscape-2025/)
+- [Hologrow](https://hologrow.ai/) · [AI loyalty program generator](https://hologrow.ai/loyalty-program-generator)
+- [Loyalty Juggernaut (GRAVTY)](https://www.lji.io/) · [Forrester Wave Q4 2025 recognition](https://www.prnewswire.com/news-releases/loyalty-juggernaut-ushers-in-a-new-era-of-modern-loyalty-tech-recognized-as-a-strong-performer-in-the-forrester-wave-for-loyalty-platforms-q4-2025-302637698.html) · [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-7bxvqyb2njh6s)
+- [PAR Punchh](https://punchh.com/) · [PAR restaurant loyalty](https://partech.com/solutions/guest-engagement-platform/restaurant-loyalty-software/) · [Wallet-based loyalty / Smart Passes](https://www.verdictfoodservice.com/news/par-technology-wallet-based-loyalty-tool-restaurants/)
+
+*End of Report*

--- a/docs/prd/prd-mvp-core-earn-burn.md
+++ b/docs/prd/prd-mvp-core-earn-burn.md
@@ -1,0 +1,105 @@
+# PRD: go-loyalty-point — MVP (Core Earn & Burn Loop, Stabilized)
+
+**Status:** Draft 🟡 | **Target Release:** Q3 2026 | **Product Lead:** Dandi
+**Phase:** MVP | **Source:** `product-analysis-v2.md` §5 MVP · `trd-loyalty-platform-v2.md` Phases 0–1
+
+---
+
+## 1. Executive Summary & Problem Statement
+
+**The Problem:** The platform has a loyalty backend but the core loop does not actually work as a product. Earned points are computed with **hardcoded constants** — the configurable rules engine is dead code, so "set an earn rule" does nothing. Members have **no UI** to see a balance or redeem. The money paths (earn/redeem) have **zero tests**, and the build ships **P0 security defects** (DB credentials baked into the published Docker image, a public endpoint leaking bcrypt hashes). It cannot go live in any real environment.
+
+**The Solution:** Ship the smallest *working, safe* loop: a member joins, earns points **computed by the real rule engine**, sees a balance, and redeems — all idempotent, real-time, tenant-scoped, and observable. Fix the P0s and add tests on the money paths so the loop is trustworthy.
+
+**Why Now?** Every later phase (campaigns, tiers, gamification, AI) builds on a correct earn/burn ledger. Stabilizing and wiring the engine now is the prerequisite for all of it; shipping features on top of an untested, insecure, rules-decorative base would compound risk.
+
+---
+
+## 2. Target Audience
+
+1. **The Member (B2C, via our B2B client):** A shopper using the client's branded app/web. Wants to see balance + cash value, earn when they transact, and redeem with minimal friction.
+2. **The Operator (B2B client):** Business owner/marketer. For MVP, needs to see earn/redeem happen per member (ledger view); rule configuration is via API/us, not yet a no-code UI.
+3. **Platform Operator (us):** Needs the loop to be correct, idempotent, observable, and tenant-isolated.
+
+---
+
+## 3. Success Metrics & KPIs
+*MVP is successful if, within 90 days of launch:*
+
+- **Activation:** >60% of enrolled members earn at least once within 7 days.
+- **Correctness:** 100% of earn is computed by the rule engine (0% hardcoded); **0 balance-integrity incidents**.
+- **Real-time:** Earn-to-visible latency <2s (p99); point-award API <300ms (p99).
+- **Safety:** 0 known P0 security defects in the released build; earn/redeem covered by automated tests (`go test -race`).
+- **Isolation:** 0 cross-tenant data-leak incidents.
+
+---
+
+## 4. Scope & Non-Goals
+
+**✅ In Scope (MVP):**
+- **Stabilization (TRD Phase 0):** SOPS secrets (remove `.env` from image), remove/gate the hash-leak endpoint, implement `LogError`, stop the startup session-wipe, add `-race` to CI, tests on `RedemptionService.Create` + `TransactionService.Create`.
+- **Rule-driven earning:** wire `point_rewards_engine` into `TransactionService.Create`; delete shadow types.
+- **Member loop:** enrollment, balance + ledger display (new member UI), basic redemption at checkout.
+- **Idempotency:** transaction-ID dedupe (Redis key + unique DB constraint).
+- **Real-time event:** `points.committed` to Kafka on earn/burn; `event_log` fallback when bus down.
+- **Tenant scoping:** `tenant_id` on every record/query/event; member auth = per-tenant **local** (`auth_source = local`).
+- **Reliable transactional email** (OTP + earn/redeem confirmation).
+- **Observability baseline:** structured 5xx logging, metrics, runtime-configurable log level.
+
+**❌ Out of Scope (Non-Goals for MVP):**
+- No-code rule builder UI (rules wired but configured by API/us).
+- Tiers · Voucher campaigns · Points expiry · Gamification · Partner/coalition · AI/personalization.
+- OIDC member federation (local auth only).
+- Real-time analytics dashboards (fake demo dashboard is **removed**, not replaced yet).
+- Native mobile SDK.
+
+---
+
+## 5. Core Capabilities & User Stories
+
+### A. Member Experience (member API + embeddable UI)
+
+| Epic | User Story | Acceptance Criteria |
+|---|---|---|
+| **Enrollment** | As a member, I want to join a program and (optionally) get a welcome balance, so I start with value. | 1. Member created under correct `tenant_id`. 2. Optional starting balance applied per program config. 3. Confirmation email delivered. |
+| **Point Visibility** | As a member, I want to see my balance and its cash value, so I know my purchasing power. | 1. Balance + ledger history render in member UI. 2. UI shows cash equivalent (e.g. "500 pts = Rp 5,000"). 3. Reflects a completed transaction <2s. |
+| **Rule-driven Earning** | As a member, I want correct points when I transact, so the program is trustworthy. | 1. Points computed by the **rule engine**, not constants. 2. Same txn + different active rule → different points (regression test). 3. Ledger entry immutable with txn ID, source, resulting balance. |
+| **Redemption** | As a member, I want to redeem points for a discount/reward at checkout, so I get instant value. | 1. Balance validated before commit. 2. Deduction atomic; failed redemption deducts nothing. 3. ≤3 taps from trigger to confirmation. |
+
+### B. Operator / Platform Experience
+
+| Epic | User Story | Acceptance Criteria |
+|---|---|---|
+| **Ledger Visibility** | As an operator, I want to view a member's earn/burn history, so I can support and verify. | 1. Per-member ledger, tenant-scoped. 2. Each entry shows delta, source, balance, timestamp. |
+| **Idempotent Ingestion** | As the platform, I must never double-award on a retry. | 1. Re-submitting the same txn ID is a no-op (Redis + unique DB constraint). 2. Verified under concurrent submissions. |
+| **Safe & Observable** | As the platform, I must run with no P0 defects and full error visibility. | 1. Published image has no secrets (`docker run … cat /app/.env` fails). 2. 5xx logged via `LogError`. 3. `go test -race ./...` green in CI. |
+
+---
+
+## 6. Key Edge Cases & Error States
+
+- **Double-spend (two tabs/devices redeeming one balance).** → Ledger enforces DB locking + idempotency keys; second concurrent redeem fails with "Insufficient Balance," no negative drift.
+- **Retry / network duplicate on earn.** → Same transaction ID → idempotent no-op; balance credited exactly once.
+- **Return / refund after earn.** → Refund reverses the earn as a compensating ledger entry; balance may go negative (member earns out of "debt" before next redeem). Reversal is atomic and audited.
+- **Kafka unavailable at earn time.** → Sync ledger commit still succeeds (Kafka is fan-out, not a hard dependency); event written to PostgreSQL `event_log` and replayed.
+- **OTP email not delivered.** → "Resend code" available; enrollment not silently stuck.
+- **Cross-tenant access attempt.** → `TenantScope` middleware rejects; integration test asserts tenant A cannot read tenant B.
+
+---
+
+## 7. Technical Dependencies
+
+- **Rules engine wiring** — `ProgramRuleRepository.GetActiveRules` into `TransactionService.Create` (TRD Phase 1, S1).
+- **Event bus (Kafka)** activated with `event_log` fallback (currently imported, unused).
+- **Redis** for idempotency keys (in addition to sessions/cache).
+- **SOPS** secret management + credential rotation; CI `-race` + `govulncheck`.
+- **Email/push provider** selection (Open Question — block before launch).
+- **POS / checkout** earn-trigger via REST API.
+- **Member SDK / embeddable web widget** (B2B2C surface) for balance/redeem.
+
+---
+
+**Next Steps for the PM Team:**
+1. Confirm the Non-Goals boundary with engineering (esp. "rules wired but no builder UI yet").
+2. Resolve MVP Open Questions before build: email provider, starting-balance policy, points-liability accounting stance.
+3. Hand Core Capabilities to UX for low-fi wireframes of the member balance/redeem widget + operator ledger view.

--- a/docs/prd/prd-phase1-operator-campaigns.md
+++ b/docs/prd/prd-phase1-operator-campaigns.md
@@ -1,0 +1,101 @@
+# PRD: go-loyalty-point — Phase 1 (Operator Control & Campaign Tools)
+
+**Status:** Draft 🟡 | **Target Release:** Q4 2026 | **Product Lead:** Dandi
+**Phase:** 1 | **Depends on:** MVP complete | **Source:** `product-analysis-v2.md` §5 Phase 1 · `trd-loyalty-platform-v2.md` Phase 3
+
+---
+
+## 1. Executive Summary & Problem Statement
+
+**The Problem:** After MVP, the earn/redeem loop works but every rule and promotion still goes through us (API/engineering). Operators cannot launch a campaign, issue vouchers, or see how a program is performing on their own — and there is no points expiry, so liability never ages off and the dashboard is still fake.
+
+**The Solution:** Give operators self-serve control: a **no-code rule builder**, an **in-house voucher engine** (bulk codes, eligibility, stacking), **campaign scheduling**, **configurable points expiry** with member warnings, **fraud velocity checks**, and a **real analytics dashboard** served from ClickHouse.
+
+**Why Now?** Operator self-service is the product's core promise ("double points on weekends is a toggle, not a deploy"). It removes us from the critical path of every campaign and unlocks the time-to-campaign metric that justifies the platform.
+
+---
+
+## 2. Target Audience
+
+1. **The Campaign Manager (B2B operator, non-technical):** Wants to configure earn rules and issue vouchers visually, schedule campaigns, and watch results — no developer.
+2. **The Member (B2C):** Benefits from promotions and must be warned before points expire.
+3. **Platform Operator (us):** Needs guardrails so a bad rule can't blow up liability, and fraud controls before promotions go live.
+
+---
+
+## 3. Success Metrics & KPIs
+*Within 90 days of Phase 1 launch:*
+
+- **Operational efficiency:** Time-to-campaign <30 min via admin UI (from "API + us" today).
+- **Self-service rate:** >80% of new campaigns created without engineering involvement.
+- **Redemption:** Checkout redemption drop-off <15%.
+- **Expiry hygiene:** 100% of expiring points trigger 30/14/7-day member warnings.
+- **Fraud:** 0 successful velocity-abuse incidents on a live campaign.
+
+---
+
+## 4. Scope & Non-Goals
+
+**✅ In Scope (Phase 1):**
+- **No-code rule builder** over the existing rule model (if/then, conditions, time-bound), version-controlled (author/timestamp/diff).
+- **Voucher engine (in-house):** bulk unique single-use codes (≥10k/batch), eligibility (SKU/category/segment/channel/date), stacking rules, redemption logging.
+- **Campaign scheduling:** start/end, timezone, auto-activation.
+- **Points expiry:** configurable + 30/14/7-day warnings.
+- **Fraud velocity checks:** configurable per-program limits; admin alert + account freeze/reverse.
+- **Basic analytics dashboard** (ClickHouse): active members, earn rate, redemption rate.
+- **Customer management UI** (member entity is server-only today).
+
+**❌ Out of Scope (Non-Goals):**
+- Tiers / status (Phase 2).
+- Gamification, referrals, behavioral earning (Phase 3).
+- AI/personalization, segmentation (Phase 4).
+- OIDC member federation (Phase 2).
+- Partner/coalition (Phase 5).
+
+---
+
+## 5. Core Capabilities & User Stories
+
+### A. Operator Experience (Rules, Vouchers, Campaigns)
+
+| Epic | User Story | Acceptance Criteria |
+|---|---|---|
+| **Rule Builder** | As a marketer, I want to set "2x points on weekends for SKU X," so I run a promo without code. | 1. If/then UI with condition groups (AND/OR), event triggers, time bounds. 2. No deploy required. 3. Change logged with author/timestamp/diff. |
+| **Voucher Generation** | As a marketer, I want to bulk-issue unique codes, so I can run a coupon drop. | 1. ≥10,000 unique single-use codes in <60s. 2. Eligibility by SKU/category/segment/channel/date. 3. Stacking rules enforced per transaction. |
+| **Campaign Scheduling** | As a marketer, I want start/end dates with auto-activation, so campaigns run unattended. | 1. Timezone-aware schedule. 2. Auto-activates/deactivates. 3. Results visible within 24h. |
+| **Analytics** | As an operator, I want active members, earn rate, redemption rate, so I know if it's working. | 1. Dashboard served from ClickHouse. 2. Figures reconcile with the ledger. |
+
+### B. Member & Platform Experience
+
+| Epic | User Story | Acceptance Criteria |
+|---|---|---|
+| **Expiry Warning** | As a member, I want warning before my points expire, so I don't lose value silently. | 1. Configurable expiry per program. 2. 30/14/7-day in-app + email/push warnings. 3. Expiry runs async (Temporal), off-peak. |
+| **Fraud Controls** | As the platform, I want velocity checks + override, so promos aren't abused. | 1. Configurable max earn/redeem per member per window. 2. Alert within 60s. 3. Operator can freeze account + reverse txns without engineering. |
+| **Customer Lookup** | As an operator, I want to search/manage members, so I can support them. | 1. Tenant-scoped search. 2. View member balance, ledger, vouchers. |
+
+---
+
+## 6. Key Edge Cases & Error States
+
+- **Mass expiry at a date boundary (e.g., Dec 31).** → Expiry processed asynchronously via Temporal queue during off-peak (e.g., 02:00), batched to avoid DB spikes.
+- **Bad rule blows up liability (e.g., stackable 100% off).** → Builder validation + guardrails on save; rule version-control enables instant rollback; preview impact before activation.
+- **Voucher double-redeem / shared code.** → Single-use codes enforced atomically; second redeem fails; per-code redemption cap enforced.
+- **Fraud threshold mis-tuned → alert fatigue.** → Start conservative, per-program configurable; alerts deduplicated.
+- **Campaign overlap (two rules match one transaction).** → Defined precedence/stacking resolution; logged which rule(s) fired.
+
+---
+
+## 7. Technical Dependencies
+
+- **MVP complete:** rule engine wired, event bus active, ledger idempotent, tenant scoping.
+- **ClickHouse** analytics store + Kafka→ClickHouse consumer (TRD §3.8) — self-hosted in-cluster.
+- **Temporal** workflows for async expiry + scheduled campaign activation.
+- **CRM sync** (via n8n) — P1 integration.
+- **Admin console** front-end work for builder/voucher/campaign/dashboard.
+
+---
+
+**Next Steps for the PM Team:**
+1. Validate rule-builder guardrails + approval flow with engineering (prevent costly misconfig).
+2. Confirm ClickHouse retention/sizing (Open Question) before dashboard build.
+3. Hand voucher + rule-builder flows to UX for wireframing; design the fraud-alert action surface.

--- a/docs/prd/prd-phase2-tiers-lifecycle.md
+++ b/docs/prd/prd-phase2-tiers-lifecycle.md
@@ -1,0 +1,99 @@
+# PRD: go-loyalty-point — Phase 2 (Tiers & Member Lifecycle)
+
+**Status:** Draft 🟡 | **Target Release:** Q1 2027 | **Product Lead:** Dandi
+**Phase:** 2 | **Depends on:** Phase 1 complete | **Source:** `product-analysis-v2.md` §5 Phase 2 · `trd-loyalty-platform-v2.md` Phase 2 + §3.10
+
+---
+
+## 1. Executive Summary & Problem Statement
+
+**The Problem:** Members earn and redeem, and operators run campaigns — but there is no **status**. Every member is treated identically, so there is no long-term motivation to keep coming back, and no way for a client to reward their best customers differently. Larger B2B clients also want their customers to log in via their own SSO, which the local-only auth from MVP doesn't support.
+
+**The Solution:** A configurable **tier system** (thresholds, qualification engine, benefits, progress display, downgrade grace), plus the **OIDC federation** half of the hybrid member-auth model so SSO-demanding clients can onboard.
+
+**Why Now?** Tiers are the standard retention lever in loyalty — they convert transactional members into status-seeking ones. With the core loop and operator tooling solid, status is the highest-leverage engagement feature, and the first enterprise clients will gate on SSO.
+
+---
+
+## 2. Target Audience
+
+1. **The Member (B2C):** Wants to know their status, the benefits it unlocks, and how close they are to the next tier — and to be warned before losing it.
+2. **The Operator (B2B):** Wants to define tiers and benefits that fit their business and reward their best customers.
+3. **The Enterprise Client (B2B):** Wants their customers to authenticate via the client's own IdP (SSO), not a separate login.
+
+---
+
+## 3. Success Metrics & KPIs
+*Within 90 days of Phase 2 launch:*
+
+- **Retention lift:** Tier-qualified members retained +10pp vs. the non-tiered base.
+- **Progression:** >40% of active members view their tier-progress UI monthly.
+- **Downgrade fairness:** 100% of at-risk members receive a downgrade warning before tier loss.
+- **SSO adoption:** ≥1 client live on OIDC federation; 0 cross-tenant identity leaks.
+
+---
+
+## 4. Scope & Non-Goals
+
+**✅ In Scope (Phase 2):**
+- **Tier definition:** configurable tiers with qualifying thresholds (spend / points / visits).
+- **Tier qualification engine:** automated promote/demote on rolling or fixed window; runs on transaction + on interval (Temporal).
+- **Tier benefits:** multipliers, exclusive rewards, early access by tier.
+- **Tier progress display:** visual progress bar to next tier.
+- **Downgrade grace period:** configurable warning window + notification.
+- **OIDC member federation:** `auth_source = federated` per tenant (hybrid auth, TRD §3.10).
+
+**❌ Out of Scope (Non-Goals):**
+- Tier challenges / accelerators `[PROPOSED]` (defer; gamification-adjacent).
+- Behavioral/non-purchase earning, referrals (Phase 3).
+- AI segmentation/personalization (Phase 4).
+- SAML federation (OIDC only unless a client requires it).
+- Partner/coalition tiers (Phase 5).
+
+---
+
+## 5. Core Capabilities & User Stories
+
+### A. Member Experience
+
+| Epic | User Story | Acceptance Criteria |
+|---|---|---|
+| **Tier Status** | As a member, I want to see my tier and its benefits, so I value my status. | 1. Current tier + benefits shown in member UI. 2. Benefits (multiplier/perks) actually applied on earn. |
+| **Tier Progress** | As a member, I want a progress bar to the next tier, so I'm motivated to keep going. | 1. Shows metric + amount required to next tier. 2. Celebratory state on upgrade. |
+| **Downgrade Warning** | As a member, I want warning before losing my tier, so I can act. | 1. Notification sent within the configured grace window. 2. Clear "do X to keep your tier" message. |
+| **SSO Login** | As a member of an enterprise client, I want to log in with my existing account, so I don't make a new one. | 1. OIDC redirect to the client IdP. 2. Signed assertion (`sub` + `tenant_id`) verified against tenant JWKS. 3. No credential stored by us. |
+
+### B. Operator / System Experience
+
+| Epic | User Story | Acceptance Criteria |
+|---|---|---|
+| **Tier Definition** | As an operator, I want to define tiers and thresholds, so status fits my business. | 1. ≥3 configurable tiers. 2. One primary qualifying metric per tier (anti-confusion). 3. Rolling or fixed window selectable. |
+| **Qualification Engine** | As the system, I must promote/demote members automatically and correctly. | 1. Re-evaluates on qualifying transaction + scheduled interval (Temporal). 2. Idempotent; no flapping. 3. Emits tier-change event for notification. |
+| **Federation Config** | As an operator (enterprise), I want to register my IdP, so my customers use SSO. | 1. Per-tenant issuer/JWKS/client-id/claim-map. 2. Validated at onboarding. 3. Falls back cleanly if `auth_source = local`. |
+
+---
+
+## 6. Key Edge Cases & Error States
+
+- **Member oscillates around a threshold (promote/demote flapping).** → Hysteresis + grace window; demotion only after the qualifying window closes, not instantly.
+- **Retroactive transaction or refund changes qualification.** → Re-evaluation is idempotent; recompute from the ledger, not incremental counters.
+- **Benefit timing (when does a new multiplier apply?).** → Multiplier applies from the moment of qualification forward; never retroactively recomputes past earns.
+- **OIDC token from wrong tenant / spoofed issuer.** → Reject if issuer not the tenant's registered IdP; `tenant_id` claim must match; isolation test asserts no cross-tenant mapping.
+- **Mid-stay tier change for a transaction in flight.** → Tier resolved at transaction commit; consistent within a single transaction.
+
+---
+
+## 7. Technical Dependencies
+
+- **Phase 1 complete:** rule engine + event bus + analytics.
+- **Temporal** for scheduled tier evaluation + downgrade-warning workflows.
+- **OIDC libraries** + per-tenant IdP config store (TRD §3.10).
+- **Notification path** (Temporal/n8n) for tier upgrade/downgrade messages.
+- **Resolve Open Question:** tier qualifying window (rolling 12mo vs calendar year) before build.
+
+---
+
+**Next Steps for the PM Team:**
+1. Resolve the qualifying-window Open Question with Product before build.
+2. Confirm first federated client + that OIDC (not SAML) suffices.
+3. Hand tier-progress + status UI and SSO flow to UX for wireframing.

--- a/docs/prd/prd-phase3-gamification-behavioral.md
+++ b/docs/prd/prd-phase3-gamification-behavioral.md
@@ -1,0 +1,94 @@
+# PRD: go-loyalty-point — Phase 3 (Gamification & Behavioral Earning)
+
+**Status:** Draft 🟡 | **Target Release:** Q2 2027 | **Product Lead:** Dandi
+**Phase:** 3 | **Depends on:** Phase 2 complete | **Source:** `product-analysis-v2.md` §5 Phase 3 · `trd-loyalty-platform-v2.md` Phase 4 (behavioral triggers)
+
+---
+
+## 1. Executive Summary & Problem Statement
+
+**The Problem:** Members only earn when they spend money. Engagement is therefore bounded by purchase frequency — there's no reason to interact between purchases, and no viral acquisition loop.
+
+**The Solution:** Let members earn for **non-purchase actions** — reviews, referrals, app opens — via custom API events, plus a **referral program** and **challenges/missions**. Add streaks and badges as proposed engagement boosters.
+
+**Why Now?** With tiers driving status motivation, behavioral earning multiplies the *number of touchpoints* and adds a referral-driven acquisition channel — lowering CAC, which is the original business driver. It depends on the active event bus (from MVP) and the fraud controls (from Phase 1).
+
+---
+
+## 2. Target Audience
+
+1. **The Member (B2C):** Wants more ways to earn and to be rewarded for engagement, not just spend; wants to invite friends and benefit.
+2. **The Operator (B2B):** Wants to drive engagement frequency and acquire members cheaply via referrals.
+3. **Platform Operator (us):** Must keep non-purchase earning from becoming a fraud/abuse vector.
+
+---
+
+## 3. Success Metrics & KPIs
+*Within 90 days of Phase 3 launch:*
+
+- **Engagement frequency:** +25% non-purchase earning events per active member per month.
+- **Referral acquisition:** ≥10% of new members arrive via a referral code.
+- **Challenge completion:** >30% of members who start a challenge complete it.
+- **Abuse control:** Referral/behavioral fraud rate <2% of awarded events.
+
+---
+
+## 4. Scope & Non-Goals
+
+**✅ In Scope (Phase 3):**
+- **Behavioral event earning:** points from custom API events (review, referral, app open) via the event bus, real-time.
+- **Referral program:** unique per-member codes; referrer + referee both earn on referee activation.
+- **Challenges & missions:** multi-step tasks with a defined completion reward; progress visible.
+- **Streak bonuses** `[PROPOSED]`: consecutive-activity rewards (daily/weekly).
+- **Badges / achievements** `[PROPOSED]`: non-monetary milestone recognition.
+
+**❌ Out of Scope (Non-Goals):**
+- AI segmentation, churn, next-best-offer (Phase 4).
+- Leaderboards, spin-the-wheel (not evidenced as needed; defer).
+- Partner/coalition earning (Phase 5).
+
+---
+
+## 5. Core Capabilities & User Stories
+
+### A. Member Experience
+
+| Epic | User Story | Acceptance Criteria |
+|---|---|---|
+| **Behavioral Earning** | As a member, I want points for a review/app-open, so I'm rewarded for engaging. | 1. Custom API event triggers earn within 5s. 2. Event types extensible via API (not just purchases). 3. Ledger records source = event type. |
+| **Referral** | As a member, I want a code that rewards me and my friend, so I invite people. | 1. Unique per-member code. 2. Both earn only on referee **activation** (not signup). 3. Referrals capped per member. |
+| **Challenges** | As a member, I want a multi-step mission with a reward, so I have a goal. | 1. Challenge = steps + reward + deadline. 2. Progress visible in member UI. 3. Completion auto-grants reward + notifies. |
+| **Streaks** `[PROPOSED]` | As a member, I want a bonus for consecutive activity, so I build a habit. | 1. Configurable daily/weekly streak. 2. Reset rules clear; progress shown. |
+
+### B. Operator / System Experience
+
+| Epic | User Story | Acceptance Criteria |
+|---|---|---|
+| **Event Configuration** | As an operator, I want to define which actions earn and how much, so I shape engagement. | 1. Event-type → reward mapping via rule builder. 2. Time-bound + segment-targetable. |
+| **Abuse Control** | As the platform, I must stop referral/behavioral farming. | 1. Velocity checks (Phase 1) extended to non-purchase events. 2. Self-referral / duplicate-device blocked. 3. Suspicious activity alerts. |
+
+---
+
+## 6. Key Edge Cases & Error States
+
+- **Self-referral / circular referral.** → Block referee = referrer; detect shared device/payment fingerprint; require genuine activation.
+- **Referral awarded then referee refunds/churns immediately.** → Award gated on activation threshold (e.g., first qualifying purchase), reversible if reversed within window.
+- **Behavioral event spam (script hits "app open" 1000×).** → Velocity caps per event type per window; idempotency on event ID.
+- **Challenge completion race (two events complete simultaneously).** → Idempotent completion; reward granted exactly once.
+- **Streak timezone ambiguity.** → Streak window evaluated in the member's/tenant's configured timezone, consistently.
+
+---
+
+## 7. Technical Dependencies
+
+- **MVP event bus** active (Kafka) for real-time behavioral events.
+- **Phase 1 fraud velocity checks** — extended to non-purchase events.
+- **Temporal** for challenge/streak evaluation + reward granting.
+- **Member SDK** must emit custom events (app open, review) from the client app.
+
+---
+
+**Next Steps for the PM Team:**
+1. Decide which `[PROPOSED]` mechanics (streaks/badges) make the cut vs. defer.
+2. Define the referee "activation" event with operators (signup vs first purchase).
+3. Hand challenge + referral flows to UX; design anti-abuse messaging.

--- a/docs/prd/prd-phase4-personalization-ai.md
+++ b/docs/prd/prd-phase4-personalization-ai.md
@@ -1,0 +1,95 @@
+# PRD: go-loyalty-point — Phase 4 (Personalization & AI)
+
+**Status:** Draft 🟡 | **Target Release:** Q3 2027 | **Product Lead:** Dandi
+**Phase:** 4 | **Depends on:** Phase 3 complete + data-volume threshold met | **Source:** `product-analysis-v2.md` §5 Phase 4 · `trd-loyalty-platform-v2.md` Phase 4
+
+---
+
+## 1. Executive Summary & Problem Statement
+
+**The Problem:** Every member in the same tier sees the same offers. Rewards are not matched to individual behavior, so high-value and at-risk members are treated identically — wasting reward budget on those who'd buy anyway and missing those about to churn.
+
+**The Solution:** Move from rule-based to **intent-driven**: member **segmentation** (RFM, tier, category affinity), **segment-based offers**, a **churn-prediction trigger** that auto-sends retention offers, **next-best-offer** recommendations, and **A/B testing** to validate reward mechanics.
+
+**Why Now?** Only after Phases 1–3 has the platform accumulated enough behavioral data (purchases, redemptions, behavioral events) to train models. Personalization is gated on data volume — doing it earlier would produce unreliable models on thin data.
+
+---
+
+## 2. Target Audience
+
+1. **The Member (B2C):** Wants relevant offers — rewards that match what they actually want, surfaced at the right moment.
+2. **The Operator (B2B):** Wants to spend reward budget efficiently — retain at-risk members, not subsidize loyal ones.
+3. **Data/Platform team (us):** Needs reliable models, a clear churn definition, and a way to measure lift.
+
+---
+
+## 3. Success Metrics & KPIs
+*Within 90 days of Phase 4 launch (post data-threshold):*
+
+- **Churn model quality:** ≥0.70 precision @ ≥0.50 recall on held-out validation; **beats a recency heuristic baseline**.
+- **Retention lift:** at-risk members receiving an auto-offer retained +X pp vs. control (set per tenant).
+- **Personalization lift:** segment-based offers show higher redemption rate vs. blanket offers (A/B proven, 95% confidence).
+- **Budget efficiency:** reward spend per retained member down vs. Phase 3 baseline.
+
+---
+
+## 4. Scope & Non-Goals
+
+**✅ In Scope (Phase 4):**
+- **Member segmentation:** rule-based cohorts (RFM, tier, category affinity); daily recompute, real-time for high-value segments.
+- **Segment-based offers:** different earn/redemption rules per segment.
+- **Churn-prediction trigger** `[PROPOSED]`: at-risk members auto-receive a retention offer.
+- **Next-best-offer** `[PROPOSED]`: AI recommends the most relevant reward at the right moment.
+- **A/B testing:** test reward values/mechanics on member subsets with significance reporting.
+
+**❌ Out of Scope (Non-Goals):**
+- Partner/coalition (Phase 5).
+- Real-time per-impression bidding / deep personalization beyond next-best-offer.
+- Building before the **data-volume threshold** is met (gate, not a goal).
+
+---
+
+## 5. Core Capabilities & User Stories
+
+### A. Member Experience
+
+| Epic | User Story | Acceptance Criteria |
+|---|---|---|
+| **Relevant Offers** | As a member, I want offers that fit me, so rewards feel personal. | 1. Two members in the same tier can receive different offers based on behavior. 2. Offer surfaced at a relevant moment. |
+| **Retention Offer** `[PROPOSED]` | As an at-risk member, I want a reason to stay, so I don't drift away. | 1. At-risk segment auto-receives a retention offer. 2. No manual intervention. 3. Suppressed if member recently active. |
+
+### B. Operator / System Experience
+
+| Epic | User Story | Acceptance Criteria |
+|---|---|---|
+| **Segmentation** | As an operator, I want dynamic cohorts, so I target precisely. | 1. Segments by RFM/tier/affinity/behavioral history. 2. Recompute ≥ daily; real-time for high-value. |
+| **A/B Testing** | As an operator, I want to test reward mechanics, so I ship what works. | 1. Define audience split. 2. Auto-report at test end with statistical significance (95%). |
+| **Churn Model** `[PROPOSED]` | As the system, I must flag at-risk members reliably. | 1. ≥0.70 precision @ ≥0.50 recall on held-out set. 2. At-risk surfaced as a targetable segment. 3. Beats recency baseline. |
+
+---
+
+## 6. Key Edge Cases & Error States
+
+- **Thin data per tenant (below threshold).** → Feature gated: ship rule-based segments only; hold ML churn until ≥6mo history + ≥10k active members + ≥100k transactions per tenant.
+- **Churn false positives waste budget.** → Precision bar enforced; cap retention-offer spend; require beating the heuristic baseline before auto-trigger goes live.
+- **Member gets retention offer right after buying.** → Suppress if recently active; recompute at-risk on latest behavior.
+- **Segment overlap / conflicting offers.** → Defined priority; one offer per member per moment.
+- **PII in model training.** → Training data anonymized/pseudonymized; no raw PII in features.
+- **A/B contamination (member in two tests).** → Mutually exclusive assignment; logged.
+
+---
+
+## 7. Technical Dependencies
+
+- **Data-volume threshold met** (TRD): ≥6mo history + ≥10k active members + ≥100k txns/tenant.
+- **ClickHouse** analytics store live (from Phase 1) as the feature/training source.
+- **Churn definition** agreed: "no qualifying activity in N days," N = 2–3× median inter-purchase interval per tenant.
+- **CDP / data-warehouse export** (P2 integration) for model pipelines.
+- **Behavioral event history** (from Phase 3) as model features.
+
+---
+
+**Next Steps for the PM Team:**
+1. Confirm the churn definition with Data + Product before Phase 3 ends.
+2. Verify the data-volume gate per target tenant — do not start modeling below it.
+3. Decide which `[PROPOSED]` AI features ship first (churn vs next-best-offer); hand A/B + segmentation UI to UX.

--- a/docs/prd/prd-phase5-partner-coalition.md
+++ b/docs/prd/prd-phase5-partner-coalition.md
@@ -1,0 +1,92 @@
+# PRD: go-loyalty-point — Phase 5 (Partner & Coalition)
+
+**Status:** Gated 🔴 (do not start without a signed partner) | **Target Release:** TBD (12+ wks after Phase 4, or parallel if partner committed) | **Product Lead:** Dandi
+**Phase:** 5 | **Depends on:** Phase 4 complete + **signed partner commitment** | **Source:** `product-analysis-v2.md` §5 Phase 5 · `trd-loyalty-platform-v2.md` §3.7
+
+---
+
+## 1. Executive Summary & Problem Statement
+
+**The Problem:** Members earn and redeem within a single brand. There is no way to earn at one partner and redeem at another, which is the stickiness driver coalition programs (supermarket + pharmacy + fuel) rely on.
+
+**The Solution:** Enable **multi-brand earning** into one unified balance, a **partner admin portal**, automated **financial settlement** of earn liability between partners, and **white-label member portals** so each brand keeps its own UX.
+
+**Why Now?** Only after a single-brand program is proven and a **partner is actually committed**. This phase is **gated**: building coalition infrastructure speculatively is wasted effort. The tenant model (TRD §3.7) already keeps this a lift, not a rewrite — so we lose nothing by waiting.
+
+---
+
+## 2. Target Audience
+
+1. **The Member (B2C):** Wants one balance usable across partner brands — earn at the grocer, redeem at the fuel station.
+2. **The Partner Operator (B2B):** Each partner brand wants its own admin view and branded member experience.
+3. **Finance (partners + us):** Need automated, auditable settlement of who owes whom for earned/redeemed liability.
+
+---
+
+## 3. Success Metrics & KPIs
+*Within 90 days of a coalition going live:*
+
+- **Cross-brand usage:** ≥20% of coalition members earn at >1 partner.
+- **Cross-brand redemption:** ≥10% of redemptions use points earned at a different partner.
+- **Settlement accuracy:** 100% of inter-partner liability reconciles automatically; 0 manual disputes unresolved >7 days.
+- **Stickiness:** coalition-member retention > single-brand baseline.
+
+---
+
+## 4. Scope & Non-Goals
+
+**✅ In Scope (Phase 5):**
+- **Multi-brand earning** `[PROPOSED]`: points earned across partner network, pooled into one balance.
+- **Partner admin portal** `[PROPOSED]`: separate operator view per partner brand.
+- **Financial settlement** `[PROPOSED]`: automated earn-liability attribution + reconciliation between partners.
+- **White-label member portal** `[PROPOSED]`: each brand maintains its own branded member UX.
+
+**❌ Out of Scope (Non-Goals):**
+- Anything before a signed partner — this whole phase is gated.
+- Real-time inter-bank settlement (batch reconciliation is sufficient initially).
+- Cross-currency coalition (single currency first).
+
+---
+
+## 5. Core Capabilities & User Stories
+
+### A. Member Experience
+
+| Epic | User Story | Acceptance Criteria |
+|---|---|---|
+| **Unified Balance** | As a member, I want one balance across partners, so points are simple. | 1. Earn at Partner A and redeem at Partner B on one balance. 2. Single identity across partners; tenant/coalition-scoped. |
+| **Branded Experience** | As a member, I want each brand to look like itself, so it feels native. | 1. White-label portal per partner. 2. Shared balance, distinct branding. |
+
+### B. Partner / Finance Experience
+
+| Epic | User Story | Acceptance Criteria |
+|---|---|---|
+| **Partner Admin** | As a partner operator, I want my own view, so I manage my slice. | 1. Per-partner admin scope. 2. Sees own earn/redeem; aggregate-only on shared members (privacy). |
+| **Settlement** | As finance, I want automated liability attribution, so partners are squared up. | 1. Earn/redeem attributed to the originating/redeeming partner. 2. Periodic reconciliation report. 3. Full audit trail. |
+
+---
+
+## 6. Key Edge Cases & Error States
+
+- **Member earns at A, redeems at B, then refunds at A.** → Compensating ledger entry attributed to A; settlement adjusts; balance may go negative until re-earned.
+- **Partner leaves the coalition with outstanding member balances.** → Defined wind-down: liability frozen/settled per contract; members notified.
+- **Privacy across partners.** → Member PII shared only at aggregate level between partners; per-partner views never expose another partner's customer data (isolation tests).
+- **Settlement dispute / mismatch.** → Immutable audit trail per transaction; reconciliation flags deltas for review.
+- **Double-attribution of one earn.** → Idempotent attribution keyed by transaction ID.
+
+---
+
+## 7. Technical Dependencies
+
+- **Signed partner commitment** — hard gate; nothing starts without it.
+- **Phase 4 complete** (or explicit decision to run as a parallel track for a committed partner).
+- **Tenant/coalition model** (TRD §3.7) — extend tenant tree to a coalition grouping.
+- **Settlement/finance integration** — reconciliation export to partner finance systems.
+- **White-label theming** in the member SDK/portal.
+
+---
+
+**Next Steps for the PM Team:**
+1. **Do not start** until a partner contract is signed — confirm the gate with leadership.
+2. When a partner commits: validate the settlement model with Finance + partner Finance first.
+3. Scope white-label theming and per-partner admin isolation with UX + engineering.

--- a/docs/product-analysis-v2.md
+++ b/docs/product-analysis-v2.md
@@ -1,0 +1,362 @@
+# Product Requirements Document — Loyalty & Rewards Platform
+> Version: 2.0 (replaces product-analysis-20260623.md)
+> Author: Claude (Opus 4.8) — Senior Product Manager
+> Date: 2026-06-24
+> Inputs: codebase analysis (`code-analysis-20260623.md`) · `loyalty-platform-research-prompt.md` (market research) · `loyalty-research-methodology.md` (Build/Buy/Compose framework) · cross-referenced with `trd-loyalty-platform-v2.md` for resolved technical decisions
+
+---
+
+## 1. Product Vision
+
+go-loyalty-point is a **B2B2C loyalty engine for Southeast Asian businesses** — a platform our B2B clients use to run points-and-rewards programs *and* to power their own customers' earn/redeem experience. We optimize for one outcome: **a member earns and redeems points with zero friction, and an operator configures the rules behind it with zero engineering**. The product bet: most SMB and mid-market merchants in Indonesia don't want to build a loyalty ledger or hire engineers to change an earn rule — they want a reliable, embeddable engine where "double points on weekends" is a toggle, not a deploy.
+
+---
+
+## 2. Current State Audit
+
+### 2.1 What Is Already Built
+Derived from `code-analysis-20260623.md`. "Built" = server logic exists and is reachable; UI status noted separately.
+
+| Feature | Status | Notes |
+|---|---|---|
+| **Account & Access** | | |
+| Business sign-up | Built | Name/email/password/phone |
+| Email OTP verification | Partial | Server issues code; email delivery unreliable (test endpoint exists to fetch code) |
+| Login / logout | Built | bcrypt + random-token session (not JWT) |
+| Account lockout | Built | 5 failed logins → 30 min lock (server-side) |
+| **Merchant (Store) Management** | | |
+| Store CRUD (add/edit/deactivate/list) | Built | Full admin UI exists |
+| **Programs & Rules** | | |
+| Program rule CRUD | Built (data only) | Tables + API exist; rules **never applied** to point math |
+| View program rules | Partial | Read-only UI |
+| **Points** | | |
+| Transactional earning | Broken-by-design | Works, but uses **hardcoded constants**, not the rule engine |
+| Points ledger | Built | Atomic CTE-based balance insert; sound. Server-only, no UI |
+| Earn / redeem points | Built (untested) | Server logic exists; `RedemptionService.Create` has **zero tests** |
+| **Rewards & Redemptions** | | |
+| Reward CRUD | Built | Server-only, no UI |
+| Redemption flow | Built (untested) | Server-only, no UI |
+| **Customers** | | |
+| Customer (member) management | Built | First-class entity, server-only, no UI |
+| **Supporting** | | |
+| Dashboard | Broken-as-product | Shows fake "Sales" template demo data |
+| Billing / Profile pages | Placeholder | Template sample content |
+| API docs (Swagger) | Built | `/swagger` |
+| Health check | Built | `/ping` checks PG primary/replica/Redis |
+| Event log | Built | Synchronous writes to PostgreSQL `event_log` (Kafka imported but unused) |
+
+### 2.2 What Is Missing vs. Market Standard
+Cross-referenced against `loyalty-platform-research-prompt.md` Document B. Gaps only.
+
+| Gap | Market Standard | Impact if Missing |
+|---|---|---|
+| Rules actually drive point math | Runtime-configurable earn rules (Doc B1.2) | **High** — core differentiator is decorative; "set a rule" does nothing |
+| Member-facing UI for points/rewards/redeem | Member dashboard + redemption flow (Doc D1) | **High** — core value unreachable by end users |
+| Real-time earn feedback | Event-driven instant award (Doc F1) | **High** — Kafka unused; no instant "you earned X" |
+| Points expiry | Configurable expiry + warnings (Doc B1.1) | **High** — no expiry logic; liability never ages off |
+| Tiers & status | ≥3 configurable tiers (Doc B1.4) | Medium — no long-term engagement hook |
+| Voucher engine | Bulk codes, stacking, eligibility (Doc B1.5) | Medium — no promo mechanism |
+| Real analytics | Earn/burn ratio, lifecycle, cohort (Doc B1.9) | **High** — dashboard is fake demo data |
+| Gamification | Challenges, streaks, badges (Doc B1.6) | Low — engagement, not core |
+| Personalization / AI | Segments, churn, next-best-offer (Doc B1.7) | Low — later-stage |
+| Reliable transactional email | OTP / lifecycle email (Doc D) | **High** — blocks enrollment today |
+
+### 2.3 Technical Debt Affecting Product Decisions
+Only debt that **constrains feature delivery** (evidence in `code-analysis-20260623.md`):
+
+- **Rules engine is dead code** (`point_rewards_engine.go` never called; S1). → Configurable earning cannot ship until wired. **Blocks MVP.**
+- **No event system active** (Kafka imported, unused). → No real-time awards, no async notifications, no analytics stream until activated (TRD Phase 1).
+- **Money paths untested** (`RedemptionService.Create`, `TransactionService.Create` are 1-line stubs; S8). → Cannot trust earn/redeem correctness; **must add tests before MVP** is credible.
+- **P0 security defects** (creds in image C1; bcrypt-hash leak C2; silent 5xx C3; session wipe on restart C4). → Cannot go to any real environment until fixed. **Blocks everything.**
+- **No observability** (no metrics/tracing; 5xx silently swallowed). → Cannot operate or debug a live program.
+- **Single developer.** → Sequencing must be ruthless; parallel tracks unrealistic.
+
+---
+
+## 3. Target Users
+
+### User Type 1: Member (end customer of our B2B client)
+- **Who they are:** A shopper who earns/redeems at our client's business. They interact with the client's branded app/web (B2B2C), powered by our engine.
+- **Core jobs to be done:** See my balance; understand what it's worth; earn points when I transact; redeem for something I want with minimal friction.
+- **Success metric:** Activation rate — % of enrolled members who earn at least once within 7 days (>60%).
+
+### User Type 2: Operator (our B2B client's business owner / marketer)
+- **Who they are:** The business owner or marketer who signs up, registers stores, defines programs and earning rules, and runs campaigns.
+- **Core jobs to be done:** Set up a program; change earn rules without engineering; run a time-limited campaign; see whether it's working.
+- **Success metric:** Time-to-campaign — launch a bonus-points campaign in <30 min via admin UI, no engineering.
+
+### User Type 3: Platform Operator (us — internal ops/eng)
+- **Who they are:** Our team operating the multi-tenant platform.
+- **Core jobs to be done:** Keep earn/redeem correct and observable; detect fraud; onboard tenants (incl. optional SSO federation).
+- **Success metric:** 99.9% ledger uptime; zero balance-integrity incidents.
+
+---
+
+## 4. Goals & Success Metrics
+
+| Goal | Metric | Target | Phase |
+|---|---|---|---|
+| Members earn their first points | Activation rate | >60% within 7 days of enrollment | MVP |
+| Earn/redeem is correct and safe | Balance-integrity incidents | 0 | MVP |
+| Real-time feedback | Earn-to-visible latency (p99) | <2s | MVP |
+| Operators launch a campaign without engineering | Time-to-campaign | <30 min via admin UI | Phase 1 |
+| Redemption is frictionless | Redemption drop-off at checkout | <15% | Phase 1 |
+| Configurable rules actually work | % earn computed by rule engine (not constants) | 100% | MVP |
+| Members stay engaged via status | Tier-qualified member retention vs. base | +10pp | Phase 2 |
+| Tenant isolation holds | Cross-tenant data-leak incidents | 0 | MVP |
+
+---
+
+## 5. Phased Roadmap
+
+Sequence basis: **dependency order → member value → operator control**. Phases map to TRD: PRD MVP ≈ TRD Phase 0+1; PRD Phase 1 ≈ TRD Phase 3; PRD Phase 2 ≈ TRD Phase 2 tiers; PRD Phases 3–4 ≈ TRD Phase 4. (Stabilization/security from TRD Phase 0 is folded into MVP release criteria — non-negotiable.)
+
+---
+
+### MVP — Core Earn & Burn Loop (stabilized)
+**Goal:** A member can join, earn points (computed by real rules), and redeem them. An operator can see it happen. The system is safe and observable.
+**Timeframe:** ~6–8 weeks (includes ~2 weeks stabilization).
+**Release criteria:** A real member completes earn → redeem in one session with no manual intervention; points are computed by the rule engine; zero known P0 security defects; earn/redeem covered by automated tests.
+
+#### Features
+| # | Feature | Description | User |
+|---|---|---|---|
+| 1 | Stabilization (P0 fixes) | Remove creds-from-image (SOPS), kill hash-leak endpoint, implement `LogError`, stop startup session-wipe | Platform |
+| 2 | Member enrollment | Member joins a program under a tenant; optional starting balance | Member |
+| 3 | Rule-driven transactional earning | Points awarded on a transaction, **computed by the wired rule engine** (fixes the dead-code gap) | Member |
+| 4 | Points balance + ledger display | Member sees current balance + earn/burn history (new member UI) | Member |
+| 5 | Basic redemption | Member redeems points for a discount / reward at checkout; atomic, idempotent | Member |
+| 6 | Real-time earn event | `points.committed` emitted on earn/burn; balance visible <2s | Member |
+| 7 | Idempotent earn/burn | Transaction-ID dedupe (Redis + DB constraint) — no double-award on retry | System |
+| 8 | Operator ledger view | Operator views earn/burn history per member | Operator |
+| 9 | Tenant scoping | Every record/query/event scoped by `tenant_id`; member auth = per-tenant local (`auth_source = local`) | System |
+| 10 | Reliable transactional email | OTP + earn/redeem confirmation actually delivered | Both |
+
+#### Out of Scope for MVP
+- Tiers · Voucher campaigns · No-code rule builder UI (rules wired but configured by us/API in MVP) · Gamification · Partner earning · AI/personalization · OIDC federation (local auth only) · Real-time analytics dashboards · Native mobile SDK.
+
+#### Risks
+| Risk | Mitigation |
+|---|---|
+| Rules-engine wiring corrupts ledger balances | Idempotency + ledger-reconciliation tests before merge; dry-run on staging |
+| P0 creds already leaked from published image | Rotate all creds; audit registry access |
+| Adding tests surfaces latent money-path bugs | Treat as MVP scope, fix as found — do not defer |
+| Email delivery still unreliable | Verify provider end-to-end + add "resend code" before launch |
+
+---
+
+### Phase 1 — Operator Control & Campaign Tools
+**Goal:** Operators configure and launch earning campaigns and vouchers without writing code.
+**Timeframe:** ~8–12 weeks after MVP.
+**Release criteria:** An operator creates, publishes, and monitors a time-limited bonus-points campaign entirely via admin UI.
+
+#### Features
+| # | Feature | Description | User |
+|---|---|---|---|
+| 1 | No-code rule builder | If/then campaign logic (e.g., 2x points on weekends) over the existing rule model | Operator |
+| 2 | Voucher generation (in-house) | Bulk creation of unique single-use codes (≥10k/batch) — **built, not Voucherify** | Operator |
+| 3 | Voucher eligibility rules | Restrict by SKU, category, segment, channel, date range | Operator |
+| 4 | Voucher stacking rules | Control which vouchers combine per transaction | Operator |
+| 5 | Campaign scheduling | Start/end dates, timezone, auto-activation | Operator |
+| 6 | Basic analytics dashboard | Active members, earn rate, redemption rate (served from ClickHouse) | Operator |
+| 7 | Points expiry | Configurable expiry + 30/14/7-day member warnings | Both |
+| 8 | Fraud velocity checks | Configurable max earn/redeem per member per window; admin alert + freeze/reverse | Operator |
+| 9 | Customer management UI | Add/look up members (entity is server-only today) | Operator |
+
+#### Dependencies
+- MVP complete: rule engine wired, event bus active (Kafka), ledger idempotent, tenant scoping.
+- ClickHouse analytics path stood up (TRD §3.8) for the dashboard.
+
+#### Risks
+| Risk | Mitigation |
+|---|---|
+| No-code builder produces unmaintainable/costly rule logic | Guardrails + rule version-control (author/timestamp/diff); validation on save |
+| Bulk voucher generation performance | Target 10k codes <60s; load-test |
+| Fraud thresholds mis-tuned → alert fatigue | Start conservative; make per-program configurable |
+
+---
+
+### Phase 2 — Tiers & Member Lifecycle
+**Goal:** Members have a status level unlocking differentiated benefits and motivating long-term engagement.
+**Timeframe:** ~10–14 weeks after Phase 1.
+**Release criteria:** A member qualifies for a tier, sees new status + benefits, and gets a downgrade warning before losing tier.
+
+#### Features
+| # | Feature | Description | User |
+|---|---|---|---|
+| 1 | Tier definition | Configurable tiers with qualifying thresholds (spend/points/visits) | Operator |
+| 2 | Tier qualification engine | Automated promote/demote on rolling or fixed window; runs on transaction + interval (Temporal) | System |
+| 3 | Tier benefits | Multipliers, exclusive rewards, early access by tier | Member |
+| 4 | Tier progress display | Visual progress bar to next tier | Member |
+| 5 | Downgrade grace period | Configurable warning window before tier loss + notification | Both |
+| 6 | OIDC member federation | `auth_source = federated` for SSO-demanding clients (hybrid auth fast-follow, TRD §3.10) | Member |
+| 7 | Tier challenge `[PROPOSED]` | Accelerated path to next tier via a defined challenge | Member |
+
+#### Risks
+| Risk | Mitigation |
+|---|---|
+| Over-complex tier rules confuse members | One primary qualifying metric per tier (research D5) |
+| Qualification window ambiguity | Resolve Open Question §9 before build |
+
+---
+
+### Phase 3 — Gamification & Behavioral Earning
+**Goal:** Members earn for non-purchase actions — reviews, referrals, streaks — raising engagement frequency.
+**Timeframe:** ~8–10 weeks after Phase 2.
+**Release criteria:** A member completes a non-purchase action and sees points awarded in real time.
+
+#### Features
+| # | Feature | Description | User |
+|---|---|---|---|
+| 1 | Behavioral event earning | Points from custom API events (review, referral, app open) via event bus | Member |
+| 2 | Referral program | Unique per-member codes; referrer + referee earn on activation | Member |
+| 3 | Challenges & missions | Multi-step tasks with a defined completion reward | Member |
+| 4 | Streak bonuses `[PROPOSED]` | Consecutive-activity rewards (daily/weekly) | Member |
+| 5 | Badges / achievements `[PROPOSED]` | Non-monetary milestone recognition | Member |
+
+#### Risks
+| Risk | Mitigation |
+|---|---|
+| Behavioral earning becomes a fraud vector | Velocity checks (from Phase 1) extended to non-purchase events |
+| Referral abuse | Cap referrals/member; require referee activation before award |
+
+---
+
+### Phase 4 — Personalization & AI
+**Goal:** Offers/rewards dynamically matched to individuals by behavior and predicted intent.
+**Timeframe:** ~12–16 weeks after Phase 3.
+**Release criteria:** System surfaces a different offer to two members in the same tier based on their behavior profiles.
+
+#### Features
+| # | Feature | Description | User |
+|---|---|---|---|
+| 1 | Member segmentation | Rule-based cohorts (RFM, tier, category affinity) | Operator |
+| 2 | Segment-based offers | Different earn/redemption rules per segment | Operator |
+| 3 | Churn prediction trigger `[PROPOSED]` | At-risk members auto-receive a retention offer | System |
+| 4 | Next-best-offer `[PROPOSED]` | AI recommends most relevant reward at the right moment | Member |
+| 5 | A/B testing | Test reward values/mechanics on member subsets | Operator |
+
+#### Prerequisites
+- **Min data volume** (TRD): ≥6 months history + ≥10k active members + ≥100k transactions per tenant. Below this, rule-based segments only.
+- ClickHouse analytics store live (from Phase 1).
+- **Churn definition** agreed: "no qualifying activity in N days," N = 2–3× median inter-purchase interval per tenant.
+
+#### Risks
+| Risk | Mitigation |
+|---|---|
+| AI underperforms on thin data | Gate behind min-volume threshold; ship rule-based segments first |
+| Churn model false positives waste retention spend | Bar: ≥0.70 precision @ ≥0.50 recall; must beat a recency heuristic |
+
+---
+
+### Phase 5 — Partner & Coalition (if applicable)
+**Goal:** Members earn/redeem across more than one brand, increasing stickiness.
+**Timeframe:** 12+ weeks after Phase 4, or a parallel track **only** if a partner is already committed.
+**Release criteria:** A member earns at Partner Brand A and redeems at Brand B on one unified balance.
+
+#### Features
+| # | Feature | Description | User |
+|---|---|---|---|
+| 1 | Multi-brand earning `[PROPOSED]` | Points across partner network, pooled into one balance | Member |
+| 2 | Partner admin portal `[PROPOSED]` | Separate operator view per partner | Partner Operator |
+| 3 | Financial settlement `[PROPOSED]` | Automated earn-liability attribution between partners | Finance |
+| 4 | White-label member portal `[PROPOSED]` | Per-brand branded UX | Member |
+
+#### Gate Condition
+Do not begin without a **signed partner commitment**. Do not architect for it in MVP. (Note: the tenant model in TRD §3.7 already keeps this a lift, not a rewrite.)
+
+---
+
+## 6. UX Requirements
+From market research Document D. Apply across all phases unless noted.
+
+### Member-Facing Principles
+- Point balance visible at all times (persistent in nav/header).
+- Always show points in equivalent cash value alongside the point count.
+- Redemption ≤3 taps/clicks from trigger to confirmation.
+- Expiry warnings at 30 / 14 / 7 days via in-app + push/email.
+- Web fallback always available — never force app download (B2B2C: clients embed via API/SDK).
+
+### Admin Console Principles
+- Campaign creation completable without engineering.
+- Every destructive action (delete campaign, bulk-expire points) requires confirmation + audit-log entry.
+- Fraud alerts actionable from the alert itself.
+
+### Anti-Patterns to Avoid (Document D5) — do not ship
+- Hidden point monetary value.
+- Redemption minimums requiring >2 earn sessions to reach.
+- Silent fraud blocks with no member communication path.
+- Forced app download to access loyalty features.
+- Fake/demo data on real screens (current dashboard — remove in MVP).
+
+---
+
+## 7. Integration Requirements
+From research Document C3 + codebase audit + TRD decisions.
+
+| Integration | Type | Required By | Priority |
+|---|---|---|---|
+| POS / checkout | REST API (earn trigger) | MVP | P0 |
+| Email / push provider | Webhook via Temporal/n8n (notifications, OTP) | MVP | P0 |
+| Event bus (Kafka) | Internal event stream | MVP | P0 |
+| Client app / SDK (B2B2C member surface) | REST API + JS/web widget | MVP→Phase 2 | P0 |
+| Client IdP (OIDC) | Federated member auth | Phase 2 | P1 |
+| CRM | Bidirectional sync (via n8n) | Phase 1 | P1 |
+| ClickHouse (analytics) | Event-stream sink | Phase 1 | P1 |
+| CDP / data warehouse export | Stream/batch from ClickHouse | Phase 4 | P2 |
+| Partner POS | REST API | Phase 5 | P3 |
+
+---
+
+## 8. Non-Functional Requirements
+
+| Requirement | Target | Notes |
+|---|---|---|
+| Point award latency | <300ms p99 (sync path) | Real-time member feedback |
+| Earn-to-visible latency | <2s | Via event bus |
+| Transaction throughput | 500 TPS MVP; load-tested to 1,000 TPS | Per TRD §9 |
+| API availability | 99.9% uptime | SLA-aligned with checkout dependency |
+| Idempotency | All earn/burn endpoints | Redis key + unique DB constraint |
+| Tenant isolation | Enforced + tested | Member of tenant A cannot read tenant B |
+| Data retention | Member ledger: indefinite (double-entry audit trail) | Analytics events: 90d hot / 13mo raw (ClickHouse TTL) |
+| GDPR / PDPA | Right to erasure, consent log | Scoped into MVP data model; **active compliance deferred per §9, audit trail built now** |
+| Fraud: velocity checks | Configurable per program | Required before Phase 1 launch |
+| Secrets management | SOPS, runtime-injected | No secrets in images/committed files |
+
+---
+
+## 9. Open Questions
+
+| Question | Blocks | Owner | Due |
+|---|---|---|---|
+| Qualifying window for tiers (rolling 12mo vs. calendar year)? | Phase 2 | Product | Before Phase 1 ends |
+| Will points carry monetary liability on the balance sheet? (regulation deferred per TRD, but accounting stance needed) | MVP | Finance + Legal | Before MVP launch |
+| Churn definition for AI personalization? | Phase 4 | Data + Product | Before Phase 3 ends |
+| Email/push provider selection (for OTP + lifecycle)? | MVP | Eng | Before MVP launch |
+| First federated client + protocol (OIDC assumed; any SAML need)? | Phase 2 | Eng + Product | When first SSO client lands |
+| Starting-balance policy on enrollment (welcome bonus or zero)? | MVP | Product | Before MVP build |
+| Self-hosted Temporal persistence (reuse PostgreSQL vs Cassandra)? | MVP/Phase 1 infra | Eng | Before Phase 1 |
+
+---
+
+## 10. Glossary
+
+| Term | Definition |
+|---|---|
+| Earn | A member receiving points for a qualifying action |
+| Burn | A member spending points to obtain a reward |
+| Breakage | Points earned but never redeemed — a financial benefit to the operator |
+| Ledger | Immutable record of every point earn and burn transaction |
+| Idempotency | System safely handles duplicate requests without double-awarding |
+| Soft currency | Points with no redemption value, used for status/gamification only |
+| Qualifying window | Time period used to calculate tier status (e.g., rolling 12 months) |
+| Coalition | A loyalty program shared across multiple partner brands |
+| Tenant | A B2B client and its isolated data subtree (Merchant → Program → Customer) |
+| B2B2C | We serve B2B clients and power their end-customers' experience |
+| `auth_source` | Per-tenant member-auth mode: `local` (we hold identity) or `federated` (client IdP via OIDC) |
+| Rule engine | Configurable if/then logic that computes points — currently dead code, wired in MVP |
+
+---
+
+*This document replaces product-analysis-20260623.md. Do not maintain both in parallel.*
+*Next review: at MVP release milestone.*

--- a/docs/trd-loyalty-platform-v2.md
+++ b/docs/trd-loyalty-platform-v2.md
@@ -1,0 +1,647 @@
+# Technical Requirements Document
+## Loyalty Platform — go-loyalty-point
+
+> Version: 2.1 (Draft)
+> Author: Claude (Opus 4.8) — Principal Engineer / Solution Architect
+> Date: 2026-06-24
+> Status: Draft → Review → Approved
+> Input documents: `code-analysis-20260623.md` · `product-analysis-20260623.md` · `loyalty-platform-market-research.md`
+> **v2.0 changes:** §3 Target Architecture re-evaluated against answered §9 decisions — 500 TPS MVP target, Kafka as transaction intermediary, Temporal vs n8n for workers, in-house voucher engine, ClickHouse analytics store, B2B2C dual-facing scope, SOPS secrets, Indonesia-first. New subsections §3.5–§3.9.
+> **v2.1 changes:** §9.1 answered and folded in — **self-hosted** Temporal + ClickHouse, **K8s/Docker POC** portable to EKS/GKE without major refactor, **hybrid member-auth** (per-tenant local default + optional OIDC federation). New §3.10 (member identity & auth). Phases 1–2 and deployment §3.9 updated.
+
+---
+
+## 1. Executive Summary
+
+go-loyalty-point is a multi-tenant loyalty-points HTTP API (Go 1.23 / Gin / PostgreSQL / Redis) with a clean layered architecture but a critical gap: its central differentiator — the configurable program-rules engine — is dead code, and points are computed with hardcoded constants. The system also ships two P0 security defects (DB credentials baked into the published Docker image; a public endpoint leaking bcrypt hashes) and silently swallows 5xx errors. The target state, delivered over **5 phases (Phase 0–4, ~26–34 weeks total)**, is a stabilized, observable, event-driven loyalty engine where rules actually drive point math, members and operators have working UIs for the full earn→redeem→engage loop, and the platform moves toward segmentation and predictive personalization. **The single most critical risk is data integrity in the points ledger** — any regression in earn/burn atomicity or idempotency during the rules-engine rewiring corrupts customer balances and the financial liability record.
+
+---
+
+## 2. Current State Assessment
+
+### 2.1 System Snapshot
+- **Architecture pattern:** Monolith, layered (Handler → Service → Repository) with domain-defined repository interfaces; partial hexagonal (boundary leaks where middleware/router depend on concrete `*postgres.AuthRepository`). Manual DI in `server/bootstrap/`.
+- **Core tech stack:** Go 1.23, Gin v1.10, PostgreSQL 17 (primary + read replica), Redis (go-redis **v8, EOL**), lib/pq (raw SQL, no ORM), bcrypt + random-token auth (not JWT), zerolog, golang-migrate, swaggo. Kafka (kafka-go) imported but **unused**.
+- **Codebase age / maturity:** ~6 months; early-stage. Backend far ahead of the thin, mostly-template web UI.
+- **Team size indicators:** Single author (Dandi). Consistent style with minor drift (latency-decorator pattern only on `UserService`).
+
+### 2.2 What Works (Keep)
+- Typed domain errors (`server/domain/errors.go`) + clean HTTP mapper (`server/util/error_handler.go`).
+- Repository interfaces in domain → services depend on interfaces; mock-based test suites.
+- Parameterized queries throughout — no SQL injection observed.
+- **Atomic points ledger insert** — CTE-based balance compute+insert in `points_repository.go` avoids read-then-write races.
+- Read/write DB separation (primary RW + replica RR) wired correctly.
+- CSRF double-submit cookie; Redis session caching with DB fallback.
+- Structured zerolog logging; `/ping` health check across PG primary/replica/Redis.
+- Solid testify/suite templates (`points_service_test.go`, `auth_service_test.go`).
+
+### 2.3 What's Broken or At Risk (Fix)
+
+| Severity | Issue | Location | Impact |
+|---|---|---|---|
+| 🔴 Critical | `.env` (DB/Redis creds) baked into published Docker image (C1) | `Dockerfile:37`; pushed via `docker-publish.yml` | Credential disclosure to anyone pulling the image |
+| 🔴 Critical | Public endpoint returns bcrypt password hashes (C2) | `internal_load_test_handler.go` `GetRandomVerifiedUser`, route `/api/auth/test/random-user` | Unauthenticated hash harvest for offline cracking |
+| 🔴 Critical | `LogError` is an unimplemented stub (C3) | `server/util/error_handler.go:116` | All 5xx errors silently swallowed; zero prod visibility |
+| 🔴 Critical | All Redis sessions wiped on every startup (C4) | `cmd/api/main.go:76` `DeleteAllSession` | Every deploy/restart force-logs-out all users; rolling deploys wipe live sessions |
+| 🟡 Significant | Rules engine is dead code; hardcoded point math (S1) | `point_rewards_engine.go` (never called); `transaction_service.go` | Core feature is a façade — configured rules do nothing |
+| 🟡 Significant | `UserService` interface ≠ implementation (no ctx) (S2) | `domain/interfaces.go` vs `service/user_service.go` | Concrete type bypasses abstraction |
+| 🟡 Significant | Latency decorator swallows typed errors (S3) | `user_service.go` + `util.ServiceLatencyDecorator` | Callers lose not-found/conflict/system distinction |
+| 🟡 Significant | No graceful shutdown (S5) | `cmd/api/main.go:91` `r.Run` | SIGTERM hard-kills in-flight requests |
+| 🟡 Significant | CORS locked to `localhost:8080` (S6) | `bootstrap/router.go` | Blocks any real frontend origin |
+| 🟡 Significant | Redemption + transaction money paths untested (S8) | `redemption_service_test.go`, `transaction_service_test.go` (1-line stubs) | Highest-blast-radius code has zero coverage |
+| 🟡 Significant | CI runs `go test` **without `-race`** | `.github/workflows/go.yml` | Data races invisible |
+| 🟢 Minor | Orphaned `server/router/router.go` stub (S4); `DLE`→`IDLE` config typo (S9); misleading `go-playground` module name; `user_id` cookie not httpOnly; CSRF token values logged on mismatch; go-redis v8 EOL | various | Maintainability / minor security hardening |
+
+### 2.4 Feature Gap Summary (product analysis vs. market research)
+
+| Gap Category | Current State | Market Standard | Priority |
+|---|---|---|---|
+| Points engine | Hardcoded formulas; rules ignored | Runtime-configurable rules drive all earn/burn | 🔴 High |
+| Redemption UX | Server-only, no UI | Member discovery → select → confirm → instant payoff | 🔴 High |
+| Tier management | Not present | ≥3 configurable tiers, downgrade rules, benefits | 🟡 Medium |
+| Voucher system | Not present | Bulk gen, stacking rules, contextual eligibility | 🟡 Medium |
+| Gamification | Not present | Challenges, streaks, progress, badges | 🟢 Low |
+| Personalization / AI | None | Segments, behavioral triggers, churn prediction | 🟢 Low |
+| Analytics | Fake template dashboard | Earn/burn ratio, lifecycle, cohort, real-time, BI export | 🔴 High |
+| Mobile experience | None | Persistent balance, push, wallet, offline earn | 🟢 Low |
+| Admin / merchant console | Stores + read-only views; core actions server-only | No-code rule builder, campaign wizard, fraud dashboard | 🔴 High |
+
+> **Conflict flagged (do not silently resolve):** the product analysis lists many features as "Active," while the code analysis shows the money paths (`RedemptionService.Create`, `TransactionService.Create`) have **zero tests** and the rules engine is disconnected. Resolution: treat "Active" in the product doc as "endpoint reachable," **not** "verified correct." Phase 0 must add tests before any feature is trusted as stable.
+
+---
+
+## 3. Target Architecture
+
+> **v2 re-evaluation.** §9 answers change the architecture materially: Kafka is now a **transaction intermediary** (not just an event fan-out), Temporal is a candidate for durable workers, ClickHouse is the analytics store, and the product is **B2B2C** (a B2B platform that also powers our clients' customer-facing experiences). The 500 TPS MVP target keeps the design firmly in modular-monolith territory — no microservices needed.
+
+### 3.1 Architecture Decision
+
+- [x] **Modular monolith + durable async edge (Kafka + Temporal), refactor in place** ✅ **CHOSEN (v2)**
+- [ ] Refactor in place only (v1 position — superseded; async edge now explicit)
+- [ ] Selective extraction now
+- [ ] Full microservices migration
+- [ ] Replace with composable platform
+
+**Justification.** 500 TPS is modest — a single well-tuned Go service against PostgreSQL handles it with headroom; microservices would add operational cost and distributed-transaction complexity for no benefit at this scale and team size (one developer). The codebase already has the right bones (layered, domain interfaces, atomic ledger). So the core stays a **modular monolith**, but v2 makes the **async edge explicit**: a Kafka write-path in front of the ledger for availability/burst absorption, and a durable workflow engine (Temporal) for retried/scheduled side effects. The loyalty/voucher engine is **built in-house** (per §9) — no third-party engine. Module boundaries inside the monolith (members, points-ledger, rules, vouchers, tiers, campaigns, analytics-export) are drawn now so that any future extraction is a lift, not a rewrite.
+
+### 3.2 Target System Diagram
+
+```mermaid
+graph TD
+    subgraph Clients
+      MERCH[Merchant Admin Web]
+      CUST[Customer-facing apps<br/>B2B2C — client SDK/API]
+      POS[POS / e-commerce]
+    end
+    MERCH --> GW[Gin HTTP API :8080<br/>tenant-scoped]
+    CUST --> GW
+    POS --> GW
+    GW --> MW["Middleware: Recovery → CORS(env) → Auth → TenantScope → CSRF → RateLimit → Metrics"]
+    MW --> SVC[Service modules<br/>members · points · rules · vouchers · tiers · campaigns]
+    SVC --> RULES[Rules Engine]
+    SVC --> PGW[(PostgreSQL Primary RW<br/>ledger system-of-record)]
+    SVC --> PGR[(PostgreSQL Replica RO<br/>reads)]
+    SVC --> RD[(Redis — sessions/cache/idempotency)]
+
+    SVC -->|enqueue earn/burn intent| K[Kafka — transaction intermediary]
+    K --> LW[Ledger Writer consumer<br/>idempotent, ordered per customer]
+    LW --> PGW
+    K --> EVT[Event fan-out]
+    EVT --> TMP[Temporal workers<br/>notifications · tier eval · campaign sched · retries]
+    EVT --> CH[(ClickHouse — analytics)]
+    TMP -->|low-code integrations| N8N[n8n]
+    TMP --> MAIL[Email/SMS/Push]
+
+    GW --> OBS[Prometheus /metrics + OTel traces]
+    subgraph Secrets
+      SOPS[SOPS-encrypted config → runtime env / K8s]
+    end
+    SOPS -.-> GW
+```
+
+### 3.3 Core Design Principles
+1. **Single source of truth for balances** — PostgreSQL ledger is authoritative; Kafka and ClickHouse are derived/buffering layers, never the balance authority.
+2. **Idempotent transactions** — every earn/burn keyed by a client-supplied transaction ID; replay never double-credits (Redis idempotency key + unique DB constraint + the existing atomic CTE insert).
+3. **Rules drive math** — no hardcoded point constants; `TransactionService` MUST consult active `ProgramRule`s for every calculation.
+4. **Durable async for side effects** — notifications, tier evaluation, campaign scheduling, and analytics run off the event stream via Temporal/consumers, not inline.
+5. **Tenant isolation first** — every query, cache key, and event is scoped by tenant (merchant/client); a B2B2C surface cannot leak one client's members to another.
+6. **API-first, dual audience** — every capability exposed and tested via API before any UI; the same core API serves the merchant admin and (tenant-scoped) the clients' customer-facing apps.
+7. **Observable by default** — logs + metrics + traces; no feature is "Done" without an SLO dashboard.
+8. **Secrets only at runtime** — SOPS-encrypted, decrypted into env at deploy; never in images or committed plaintext.
+
+### 3.4 Tech Stack Decisions
+
+| Layer | Current | Recommended | Change Type | Rationale |
+|---|---|---|---|---|
+| Language | Go 1.23 | Go 1.23+ | Keep | Sound; team fluent |
+| Framework | Gin v1.10 | Gin v1.10 | Keep | Adequate at 500 TPS |
+| Primary DB (system-of-record) | PostgreSQL 17 (RW+RR) | Same | Keep | Authoritative ledger; replica for reads |
+| Cache / session / idempotency | go-redis **v8 (EOL)** | go-redis v9 | Upgrade | EOL; also hosts idempotency keys + rate-limit counters |
+| Transaction intermediary / event bus | kafka-go (unused) | kafka-go, **wired** | Activate | Burst absorption + HA write-path + event fan-out (§3.5) |
+| Workflow / worker orchestration | None (n8n referenced) | **Temporal** primary; n8n for low-code integrations | Add | Durable retries, scheduled tier eval/campaigns (§3.6) |
+| Analytics store | None | **ClickHouse** | Add | Columnar OLAP for earn/burn, cohort, real-time dashboards (§3.8) |
+| Secrets management | `.env` in image (C1) | **SOPS** → runtime env / K8s Secrets | Replace | Encrypted-at-rest config; removes C1 |
+| Search | None | None (defer) | Keep | No need |
+| Auth | bcrypt + random token | Keep; add MFA for admin; tenant claims | Improve | Token model fine; add tenant scoping + admin MFA |
+| Infra / deploy | Docker + K8s manifest | Same + SOPS; Indonesia region first | Improve | §3.9 |
+| Observability | **None** | Prometheus + OTel | Add | Largest operational gap |
+| Mobile | None | Deferred (B2B2C SDK later) | — | Customer apps are clients'; we expose API/SDK |
+
+### 3.5 Transaction Ingestion & Consistency Model (Kafka as intermediary)
+
+§9 intent: *"Kafka for async, message bus, intermediary to serve critical transactions before/after DB for HA and speed."* This is sound **if** the consistency boundary is explicit — a naive "write to Kafka, ack the client, write DB later" (write-behind) would make balances eventually-consistent and risks lost updates. Recommended model:
+
+- **Synchronous authority, async amplification (default earn/burn path).** The API validates, applies the rule engine, and commits the ledger entry to PostgreSQL **synchronously** (the CTE insert already does this atomically), then publishes a `points.committed` event to Kafka for fan-out (notifications, ClickHouse, tier eval). Client gets a strongly-consistent balance immediately. At 500 TPS this is comfortably within the <300ms p99 budget.
+- **Kafka write-buffer (opt-in, high-burst ingestion).** For bulk/offline POS or campaign spikes that exceed sync capacity, accept an earn *intent* onto Kafka, return `202 Accepted` with a transaction ID, and have the **Ledger Writer consumer** apply it idempotently, **partitioned by customer ID** so per-customer ordering is preserved. Balance for that path is eventually-consistent (seconds); the member dashboard shows "pending."
+- **Idempotency everywhere.** Client transaction ID → Redis key (fast dedupe) + unique DB constraint (authoritative dedupe). Same ID on either path is a no-op.
+- **Failure handling.** If Kafka is down, the **sync path still works** (Kafka is fan-out, not a hard dependency) — degrade by writing the event to the existing PostgreSQL `event_log` and replaying later. The buffer path returns 503 if Kafka is unavailable.
+
+> **Decision:** default to the **synchronous-authority** path for MVP correctness; ship the Kafka write-buffer as an explicit, opt-in ingestion mode for bulk/high-burst tenants. Do **not** make routine single-transaction balances eventually-consistent.
+
+### 3.6 Workflow Orchestration — Temporal vs n8n
+
+§9 asks to compare n8n with Temporal for the "worker."
+
+| Dimension | Temporal | n8n |
+|---|---|---|
+| Model | Code-defined durable workflows (Go SDK) | Visual, low-code node graphs |
+| Durability / retries | First-class: automatic retries, timers, state survives restarts | Basic retry; not built for long-lived stateful workflows |
+| Best for | Tier re-evaluation, points expiry sweeps, campaign scheduling, multi-step redemption sagas, guaranteed notification delivery | Connecting to 3rd-party SaaS (email vendor, CRM, Slack), ops glue, quick integrations |
+| Operational cost | Heavier (server + DB), but matches our reliability needs | Light, but weak for financial-grade guarantees |
+
+> **Decision:** **Temporal as the primary worker/orchestrator** for anything touching points, tiers, expiry, or guaranteed delivery — it gives durable, idempotent, retryable execution that a loyalty ledger demands. **Self-hosted** (§9.1) — Temporal server + its own PostgreSQL/Cassandra persistence, deployed in-cluster (§3.9); no Temporal Cloud dependency or per-action billing. **Keep n8n** as the low-code integration layer for non-critical external glue (e.g., marketing email vendor, CRM sync), invoked *from* Temporal activities. The current n8n reference (commit `f12954c`) is repurposed to this integration role, not the critical path.
+
+### 3.7 Multi-Tenancy & B2B2C Surface
+
+Product is B2B2C (§9: *"we serve B2B, but able to enhance/improve our B2B clients' products"*) — so the platform must serve both the **merchant admin** and, tenant-scoped, the **clients' own customers**.
+
+- **Tenant model.** Existing hierarchy (User/business → Merchant → Program → Customer) is the tenant tree. Add a `tenant_id` (business/client) propagated through auth claims, every repository query, every cache key, and every Kafka event key.
+- **Two API audiences, one core.** A `/v1/admin/*` surface (merchant operators) and a `/v1/member/*` surface (the client's end customers — balance, rewards, redeem). Both enforce `TenantScope` middleware; member tokens are scoped to a single customer within a single tenant.
+- **Isolation tests are mandatory** (added to §6.5): a member of tenant A must never read tenant B data — assert in integration tests.
+- **Member identity & auth.** Hybrid model (§9.1) — see §3.10.
+- **Delivery to clients.** Expose the member API + a thin JS/mobile SDK so B2B clients embed balance/redeem into their own apps. Native mobile SDK deferred; API + web widget first.
+
+### 3.8 Analytics Data Path (ClickHouse)
+
+- **Self-hosted** ClickHouse (§9.1), deployed in-cluster (§3.9) — no managed-service dependency or per-query billing.
+- Kafka `points.*`, `redemption.*`, `tier.*`, `campaign.*` events stream into ClickHouse via a consumer (or Kafka engine table).
+- ClickHouse powers Phase 3 dashboards (earn/burn ratio, DAU/MAU, cohort, real-time campaign performance) and ad-hoc BI — PostgreSQL stays the transactional system-of-record; ClickHouse is read-only derived analytics.
+- Export/BI to client warehouses (Phase 3 FR-3.4) reads from ClickHouse, not from the transactional DB (protects ledger performance).
+- **Retention (proposed — §9.1 left open):** raw event rows kept hot 90 days, then rolled into monthly aggregates via ClickHouse TTL + materialized views; raw retained 13 months for YoY cohort, then dropped. Tune per storage budget.
+
+### 3.9 Deployment & Region
+
+- **Portable Kubernetes from day one (§9.1).** POC runs on plain **K8s + Docker** (local kind/minikube or a single node); the manifests + container images are cloud-agnostic so promotion to **EKS or GKE** is a config/ingress/storage-class change, **no major refactor**. Avoid cloud-proprietary primitives in app code; keep dependencies (PostgreSQL, Redis, Kafka, Temporal, ClickHouse) as in-cluster deployments or swappable managed equivalents behind config.
+- **Self-hosted dependencies in-cluster** for POC: Temporal (§3.6) and ClickHouse (§3.8) run as cluster workloads; can later move to managed offerings without app changes.
+- **Indonesia-first** (§9: SEA, Indonesia MVP). Single primary region in Indonesia (e.g. GKE Jakarta `asia-southeast2` / AWS `ap-southeast-3`) for residency and latency; design for later SEA multi-region but do not build it now.
+- SOPS-encrypted config per environment; secrets decrypted at deploy into K8s Secrets / runtime env.
+- **Regulatory stance (§9):** *develop first, defer regulation.* Accepted as a deliberate MVP trade-off — but the ledger is built as a proper double-entry audit trail anyway (cheap to do now, expensive to retrofit), so points-liability compliance is a *reporting* add-on later, not a re-architecture.
+
+### 3.10 Member Identity & Auth (B2B2C — Hybrid)
+
+§9.1 decision: **hybrid**. One internal member model; authentication source is configurable **per tenant** so small clients onboard with zero integration while enterprise clients keep their own SSO.
+
+- **Default — per-tenant local identity (`auth_source = local`).** The platform stores member credentials (or passwordless/OTP), scoped to `tenant_id`. Same email can exist independently across tenants. We issue the tenant-scoped member token. Zero integration → fits Indonesia-first SMB clients.
+- **Optional — federated to client IdP (`auth_source = federated`).** Larger clients integrate via **OIDC** (preferred) or SAML: the member logs into the *client's* app, the client passes a signed assertion (`sub` + `tenant_id`), we verify against the tenant's registered IdP/JWKS and map to our member record. We store **no** credentials on this path.
+- **One token model downstream.** Both paths resolve to the same tenant-scoped member access token the `/v1/member/*` API already expects; services and the ledger never branch on auth source.
+- **Per-tenant config.** `tenant.auth_source` + (for federated) issuer URL, JWKS endpoint, client ID, claim mapping. Validated at tenant onboarding.
+- **Phasing.** Ship **local** in Phase 2 (unblocks the member dashboard + B2B2C surface); add **OIDC federation** as a fast-follow within Phase 2/early Phase 3 when the first SSO-demanding client lands. SAML deferred until required.
+- **Admin auth is unchanged** — merchant operators keep the existing token model + MFA (§6.1); only the member surface is hybrid.
+
+---
+
+## 4. Feature Decisions
+
+✅ Keep · 🔧 Improve · ➕ Add · ❌ Deprecate
+
+### 4.1 Points & Currency
+| Feature | Disposition | Notes / Requirements |
+|---|---|---|
+| Basic earn on purchase | 🔧 Improve | Works but uses hardcoded constants; must route through rules engine |
+| Multi-currency points | ➕ Add | Not present; defer to post-Phase 2 unless required |
+| Points expiry | ➕ Add | No expiry logic today; add configurable expiry (Phase 2) |
+| Points ledger / audit trail | ✅ Keep | Atomic CTE insert is sound; extend with idempotency key |
+| Partner earning | ➕ Add | Not in scope until coalition need confirmed |
+| Retroactive earning | ➕ Add | Defer |
+
+### 4.2 Redemption
+| Feature | Disposition | Notes / Requirements |
+|---|---|---|
+| Discount redemption | 🔧 Improve | Server logic exists, untested (S8), no UI |
+| Free product redemption | 🔧 Improve | `RedemptionService.Create` exists; add tests + UI |
+| Voucher redemption | ➕ Add | No voucher system today |
+| Pay-with-points (partial) | ➕ Add | Phase 2 |
+| Cashback redemption | ➕ Add | Defer |
+| Charity / donation | ➕ Add | Defer |
+
+### 4.3 Tiers & Status
+| Feature | Disposition | Notes / Requirements |
+|---|---|---|
+| Threshold-based tiers | ➕ Add | Phase 2; ≥3 configurable tiers |
+| Tier benefits engine | ➕ Add | Phase 2 |
+| Tier downgrade rules | ➕ Add | Phase 2; configurable grace period |
+| Tier challenge / accelerator | ➕ Add | Defer to Phase 4 (gamification) |
+
+### 4.4 Vouchers & Promotions
+| Feature | Disposition | Notes / Requirements |
+|---|---|---|
+| Voucher generation (bulk) | ➕ Add | Phase 2; ≥10k codes/batch |
+| Stacking rules | ➕ Add | Phase 2 |
+| Contextual eligibility | ➕ Add | Phase 2 (tier/segment/SKU/channel/date) |
+| Referral vouchers | ➕ Add | Defer |
+| Dynamic value vouchers | ➕ Add | Defer |
+
+### 4.5 Gamification
+| Feature | Disposition | Notes / Requirements |
+|---|---|---|
+| Challenges / missions | ➕ Add | Phase 2 MVP (trigger/target/reward/deadline) |
+| Streaks | ➕ Add | Defer |
+| Badges / achievements | ➕ Add | Defer |
+| Progress indicators | ➕ Add | Phase 2 (member dashboard) |
+
+### 4.6 Personalization & AI
+| Feature | Disposition | Notes / Requirements |
+|---|---|---|
+| Segment-based offers | ➕ Add | Phase 4 |
+| Behavioral triggers | ➕ Add | Phase 4 (event bus prerequisite) |
+| Predictive churn offers | ➕ Add | Phase 4; gated on data volume |
+| A/B testing on rewards | ➕ Add | Phase 4 |
+| Next-best-offer engine | ➕ Add | Defer beyond Phase 4 |
+
+### 4.7 Analytics & Reporting
+| Feature | Disposition | Notes / Requirements |
+|---|---|---|
+| Member lifecycle report | ➕ Add | Phase 3 |
+| Earn/burn ratio dashboard | ➕ Add | Phase 3 (financial liability metric) |
+| Campaign performance | ➕ Add | Phase 3 |
+| BI / data warehouse export | ➕ Add | Phase 3 |
+| Real-time dashboards | ➕ Add | Phase 3 |
+| Fake "Sales" template dashboard | ❌ Deprecate | Remove demo data; replace with real or honest empty state |
+
+### 4.8 Admin / Merchant Console
+| Feature | Disposition | Notes / Requirements |
+|---|---|---|
+| No-code rule builder | ➕ Add | Phase 3; rules already modeled in DB |
+| Campaign creation wizard | ➕ Add | Phase 3 |
+| Member/customer search & lookup | ➕ Add | Customer entity server-only today; needs UI |
+| Fraud dashboard | ➕ Add | Phase 3 (velocity checks) |
+| Voucher management | ➕ Add | Phase 3 |
+| Read-only stores/programs/transactions UI | 🔧 Improve | Fix token-name auth bug; add create flows |
+| Orphaned `server/router/router.go` | ❌ Deprecate | Delete (S4) |
+| Public load-test endpoint | ❌ Deprecate | Remove/gate (C2) |
+
+---
+
+## 5. Phased Delivery Plan
+
+### Phase Structure Rationale
+**"Stabilize before adding, core loop before intelligence."** Phase 0 is non-negotiable: the P0 security defects and silent-error stub make the system unsafe to build on, and the money paths are untested. Phase 1 makes earn→redeem→notify provably correct (and wires the rules engine — the central broken feature). Phases 2–4 layer member experience, operator tooling, then intelligence. Each phase depends on the prior.
+
+---
+
+### Phase 0 — Stabilize & De-risk
+**Goal:** Make the current system safe to build on.
+**Duration:** ~2 weeks.
+**Prerequisite for:** all subsequent phases.
+
+#### Scope
+- [ ] Fix all 🔴 Critical issues (C1–C4 from §2.3); replace `.env`-in-image with **SOPS**-managed secrets.
+- [ ] Add `-race` to CI test run.
+- [ ] Add integration-style tests for `RedemptionService.Create` and `TransactionService.Create` (target ≥80% coverage on these two services).
+- [ ] Implement `LogError` (zerolog one-liner).
+- [ ] Document all undocumented APIs in OpenAPI (regenerate Swagger, enforce in CI).
+- [ ] Observability baseline: make zerolog level runtime-configurable; ensure 5xx are logged.
+
+#### Definition of Done
+- Zero known P0 security defects; credentials rotated for any creds shipped in a published image.
+- Published Docker image contains no secrets (verified: `docker run --rm <img> cat /app/.env` fails).
+- `/api/auth/test/random-user` removed or auth-gated with password field dropped.
+- `go test -race ./...` green in CI.
+- `RedemptionService.Create` + `TransactionService.Create` covered by automated tests.
+- Restart no longer wipes active sessions (verified across a rolling restart).
+
+#### Risks
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Credentials already leaked via published image | Medium | Critical | Rotate all creds in C1/C2; audit GHCR pull logs if available |
+| Adding tests surfaces latent money-path bugs | Medium | High | Fix as found; treat as Phase 0 scope, not deferred |
+
+---
+
+### Phase 1 — Core Loop Integrity (incl. Rules Engine Wiring)
+**Goal:** Earn → Redeem → Notify works reliably, in real time, with rules actually applied.
+**Duration:** ~4–6 weeks.
+**Depends on:** Phase 0 complete.
+
+#### Functional Requirements
+
+**FR-1.1 — Points Ledger**
+- MUST record every earn and burn as an immutable entry with: customer+program ID, transaction ID, amount, timestamp, source (channel/event type), resulting balance.
+- MUST be idempotent: re-submitting the same transaction ID MUST NOT create a duplicate entry (extend the existing CTE insert with a unique transaction-ID constraint).
+- Balance MUST be consistent within 500ms of a transaction completing.
+
+**FR-1.2 — Earning Engine (Rules Wiring — fixes S1)**
+- `TransactionService.Create` MUST compute points by evaluating active `ProgramRule`s via the rewards engine — NOT hardcoded constants.
+- Earn rules MUST be configurable at runtime (no deploy) — by amount, transaction type, count, tenure, merchant, category (the rule model already supports these).
+- Shadow `Transaction`/`Program`/`ProgramRule` types in `point_rewards_engine.go` MUST be deleted; the engine MUST use domain types.
+- Concurrent transactions for one customer MUST NOT produce balance inconsistency.
+
+**FR-1.3 — Redemption Engine**
+- MUST validate available balance before committing any redemption.
+- A failed redemption MUST NOT deduct points; rollback MUST be atomic.
+- Partial redemption (pay-with-points) MUST be supported (new capability).
+
+**FR-1.4 — Real-Time Notifications (Event Bus Activation)**
+- The system MUST emit a `points.committed` event to Kafka within 2 seconds of any earn or burn (sync-authority path of §3.5).
+- Payload MUST include: tenant ID, points delta, new balance, transaction reference, trigger event type.
+- A **Temporal** workflow MUST consume the event and deliver the notification with durable retry; external delivery (email vendor) MAY route through n8n as a Temporal activity (§3.6).
+- Kafka MUST NOT be a hard dependency of the sync earn/burn commit — if the bus is unavailable, fall back to the PostgreSQL `event_log` and replay.
+
+#### Non-Functional Requirements
+| Requirement | Target |
+|---|---|
+| API response time (p99) | < 300ms |
+| Transaction throughput | ≥ **500 TPS** (MVP target, §9); load-test headroom to 1,000 TPS |
+| Points ledger uptime | 99.9% |
+| Data consistency | Strong on the sync earn/burn path; eventual (seconds) only on the opt-in Kafka write-buffer path (§3.5) |
+
+#### Technical Tasks
+- [ ] Wire `ProgramRuleRepository.GetActiveRules` into `TransactionService.Create`; apply `calculatePoints`/`evaluateRule` — Effort: L — Owner: backend.
+- [ ] Delete shadow types in `point_rewards_engine.go` — Effort: S — Owner: backend.
+- [ ] Add unique constraint + Redis idempotency check on transaction ID in ledger insert — Effort: M — Owner: backend.
+- [ ] Implement partial redemption in `RedemptionService` — Effort: M — Owner: backend.
+- [ ] Wire Kafka producer (`points.committed`) on earn/burn + Temporal notification workflow; PostgreSQL `event_log` fallback when bus down — Effort: L — Owner: backend.
+- [ ] Stand up **self-hosted** Temporal (server + persistence + Go SDK worker) as in-cluster K8s workload — Effort: M — Owner: backend.
+- [ ] Load test at 1,000 TPS (2× MVP target) — Effort: M — Owner: backend.
+
+#### Definition of Done
+- All FR-1.x pass automated integration tests.
+- Configured rules demonstrably change point math (regression test: same transaction, different rule → different points).
+- Load test at 1,000 TPS (2× MVP target) passes with no errors and p99 < 300ms.
+- Earn/burn visible downstream within 2 seconds via the event bus; Temporal notification delivered with retry.
+
+#### Risks
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Rules wiring regresses ledger correctness | Medium | Critical | Idempotency tests + ledger-reconciliation test before merge |
+| Kafka activation adds operational instability | Medium | Medium | Kafka is fan-out only on sync path; `event_log` fallback on bus failure (§3.5) |
+| Temporal adds infra/learning overhead for solo dev | Medium | Medium | Start with one workflow (notifications); expand only as needed |
+
+---
+
+### Phase 2 — Member Experience
+**Goal:** Member-facing product competitive with market standard — tiers, vouchers, gamification MVP, real member dashboard.
+**Duration:** ~6 weeks.
+**Depends on:** Phase 1 complete.
+
+#### Functional Requirements
+
+**FR-2.1 — Tier System**
+- MUST support ≥3 configurable tier levels, each with independent qualifying rules.
+- Tier evaluation MUST run on every qualifying transaction and on a configurable interval.
+- Downgrade grace periods MUST be configurable per tier.
+- Members MUST be notified on tier upgrade/downgrade (via event bus).
+
+**FR-2.2 — Voucher Engine**
+- MUST support bulk generation of unique single-use codes (≥10,000 per batch).
+- Eligibility MUST be configurable by tier, segment, SKU, channel, date range.
+- Stacking rules MUST be enforceable per transaction.
+- Every redemption MUST be logged with voucher code, customer ID, transaction value, timestamp.
+
+**FR-2.3 — Member Dashboard (closes core "no UI" gap)**
+- MUST show: current balance, pending points, expiring points (with date), tier status + progress, active vouchers, recent transaction history (≥90 days).
+- State MUST reflect completed transactions within 5 seconds.
+- MUST replace the fake "Sales" template dashboard (deprecation from §4.7).
+
+**FR-2.4 — Gamification (MVP)**
+- MUST support challenge definition: trigger event, target count/value, reward, deadline.
+- Active-challenge progress MUST be visible in the dashboard.
+- Challenge completion MUST auto-trigger the reward and notify the member.
+
+#### Technical Tasks
+- [ ] Tier model + evaluation service + migrations — Effort: L — Owner: backend.
+- [ ] Voucher engine **built in-house** (generation, eligibility, stacking, redemption log) — Effort: L — Owner: backend. *(Decision §9: build, not Voucherify.)*
+- [ ] Member dashboard UI + fix token-name auth bug (`session_token` vs `auth_token`) — Effort: L — Owner: frontend.
+- [ ] Hybrid member-auth: per-tenant **local** identity + `auth_source` config (§3.10); OIDC federation as fast-follow — Effort: L — Owner: backend.
+- [ ] Points expiry logic + expiring-soon surface — Effort: M — Owner: backend.
+- [ ] Challenge MVP service + dashboard cards — Effort: M — Owner: full-stack.
+
+#### Definition of Done
+- All FR-2.x pass integration tests.
+- Member dashboard renders correctly on mobile web (no native app this phase).
+- Voucher bulk generation completes 10,000 codes in < 60 seconds.
+- No screen displays template/demo data.
+
+---
+
+### Phase 3 — Merchant & Operations
+**Goal:** Operators run campaigns, detect fraud, and export data without engineering support.
+**Duration:** ~6–8 weeks.
+**Depends on:** Phase 2 complete.
+
+#### Functional Requirements
+
+**FR-3.1 — No-Code Rule Builder**
+- Marketers MUST create/edit/activate/deactivate earn/burn rules without a deploy (rule model already exists in DB).
+- MUST support condition groups (AND/OR), event-type triggers, segment targeting, time-bound activation, reward-type selection.
+- Rule changes MUST be version-controlled: logged with author, timestamp, diff.
+
+**FR-3.2 — Campaign Management**
+- Campaigns MUST support scheduling (start/end, timezone), audience targeting (segment or tier), reward assignment.
+- Results MUST be visible within 24 hours of launch.
+
+**FR-3.3 — Fraud Controls**
+- MUST apply configurable velocity checks: max earn per member per day/hour, max redemptions per voucher code, max referrals per member.
+- Suspicious activity MUST raise an admin alert within 60 seconds.
+- Operators MUST be able to freeze an account and reverse transactions without engineering.
+
+**FR-3.4 — Analytics & Data Export**
+- Pre-built reports MUST include: active members (DAU/MAU), earn rate, redemption rate, liability balance, top rewards, churn by cohort.
+- Member-level event data MUST export as CSV or stream to a warehouse on a configurable schedule.
+
+#### Technical Tasks
+- [ ] Rule-builder admin UI over existing `ProgramRule` API + change-log table — Effort: L — Owner: full-stack.
+- [ ] Campaign model + scheduler — Effort: L — Owner: backend.
+- [ ] Velocity-check middleware + admin alerting + account freeze/reversal — Effort: L — Owner: backend.
+- [ ] **ClickHouse** analytics store + Kafka→ClickHouse consumer + read models — Effort: L — Owner: backend.
+- [ ] Export/BI pipeline reading from ClickHouse (not transactional DB) — Effort: M — Owner: backend.
+- [ ] Customer management UI (entity is server-only today) — Effort: M — Owner: frontend.
+
+#### Definition of Done
+- A non-technical marketer creates and launches a campaign end-to-end without engineering (UAT-validated).
+- Dashboards served from **ClickHouse** (§3.8); export to client warehouse runs on schedule.
+
+---
+
+### Phase 4 — Intelligence & Personalization
+**Goal:** Move from rule-based to intent-driven.
+**Duration:** ~6–8 weeks.
+**Depends on:** Phase 3 complete + minimum member-data-volume threshold met (proposed below).
+
+#### Functional Requirements
+
+**FR-4.1 — Behavioral Triggers**
+- MUST support real-time event-driven rules firing within 5 seconds of a qualifying action.
+- Trigger events MUST be extensible via API (not limited to purchases).
+
+**FR-4.2 — Segmentation Engine**
+- Marketers MUST define dynamic segments by RFM score, tier, product affinity, behavioral history.
+- Membership MUST recalculate at least daily; real-time recalculation MUST be available for high-value segments.
+
+**FR-4.3 — Churn Prediction (MVP)**
+- MUST identify at-risk members from configurable activity signals.
+- At-risk members MUST be surfaceable as a targetable segment.
+- Automated retention offers MUST be triggerable for them without manual intervention.
+
+**FR-4.4 — A/B Testing**
+- Marketers MUST run A/B tests on reward value, type, and earn rate for defined audience splits.
+- Results MUST report automatically at test end with statistical significance indicated.
+
+#### Data Requirements (proposed — §9 deferred to "best approach")
+- **Minimum data volume before churn/segmentation is reliable:** ≥ 6 months of transaction history **and** ≥ 10,000 active members (earned ≥ once) **and** ≥ 100,000 logged transactions per tenant. Below this, ship rule-based segments only; hold ML churn until the threshold is met (avoids the thin-data failure in Risk §8).
+- **Churn label window:** define churn as "no qualifying activity in N days" where N = 2–3× the median inter-purchase interval per tenant (computed, not fixed).
+- All ML training data MUST be anonymized or pseudonymized.
+
+#### Technical Tasks
+- [ ] Behavioral-trigger engine on event bus — Effort: L — Owner: backend.
+- [ ] Segmentation engine (RFM + behavioral) — Effort: L — Owner: backend/data.
+- [ ] Churn model + at-risk segment surface — Effort: L — Owner: data science.
+- [ ] A/B test framework + significance reporting — Effort: M — Owner: backend.
+
+#### Definition of Done
+- Churn model achieves ≥ **0.70 precision at ≥ 0.50 recall** on a held-out validation set (proposed starting bar — retention spend wasted on false positives must stay bounded; tune per tenant once live). Baseline to beat: a simple recency-based heuristic.
+- A/B framework produces statistically significant results at 95% confidence.
+
+---
+
+## 6. Cross-Cutting Requirements
+
+### 6.1 Security
+- All API endpoints MUST require authentication; tokens MUST carry tenant + role scope; `TenantScope` middleware MUST enforce isolation on every request (§3.7).
+- PII in transit MUST use TLS 1.2+; at rest AES-256 minimum.
+- Admin console MUST enforce MFA.
+- `govulncheck` (or equivalent) MUST run on every build, blocking High/Critical.
+- `user_id` cookie MUST be httpOnly (fixes MEDIUM finding); stop logging CSRF token values.
+- **Secrets MUST be managed via SOPS** (encrypted at rest in the repo, decrypted into runtime env / K8s Secrets at deploy) — no plaintext secrets in images or committed files (enforced from Phase 0; replaces C1).
+
+### 6.2 Observability
+- Every service MUST emit structured JSON logs with trace ID, customer ID, event type, duration, outcome.
+- Prometheus metrics (request count, latency histogram, error rate) from Phase 1.
+- Distributed tracing (OpenTelemetry) across boundaries from Phase 1 onward.
+- SLO dashboards MUST be live before any phase is marked Done.
+- Liveness/readiness split (`/healthz/live`, `/healthz/ready`) for K8s.
+
+### 6.3 Data & Privacy
+- Members MUST be able to request full data export and account deletion within 30 days.
+- Points liability MUST be tracked as a financial ledger with full audit trail (extend existing ledger). **Note (§9):** active regulatory compliance is *deferred* for MVP, but the double-entry audit trail is built now so compliance reporting is a later add-on, not a re-architecture.
+- **Data residency: Indonesia-first** (single region), designed for later SEA multi-region (§3.9).
+
+### 6.4 API Standards
+- Public APIs MUST follow REST conventions with versioning (`/v1/`, `/v2/`).
+- No breaking changes within a version; deprecation notice ≥90 days.
+- All endpoints documented in OpenAPI 3.x, enforced via CI check.
+
+### 6.5 Testing Standards
+| Test Type | Requirement |
+|---|---|
+| Unit | ≥80% coverage on business-logic layer |
+| Integration | All API endpoints; run on every PR |
+| Contract | All service-to-service / event-bus interfaces |
+| Tenant isolation | Member of tenant A MUST NOT read tenant B data — asserted in integration tests (§3.7) |
+| Load | Before every phase release; target 1,000 TPS (2× MVP) |
+| Security scan | Every build; block on High/Critical |
+| Race detection | `go test -race` in CI (from Phase 0) |
+
+---
+
+## 7. Deprecation Plan
+
+| Item | Current Usage | Removal Phase | Migration Path | Owner |
+|---|---|---|---|---|
+| `.env` in Docker image | Built into every published image | Phase 0 | SOPS-encrypted config → runtime env / K8s Secrets | backend |
+| `/api/auth/test/random-user` | Public test endpoint leaking hashes | Phase 0 | Remove, or internal-gate + drop password field | backend |
+| `DeleteAllSession` at startup | Runs on every boot | Phase 0 | Remove; rely on Redis TTL | backend |
+| Hardcoded point constants | `transaction_service.go` | Phase 1 | Replaced by rules engine | backend |
+| Shadow types in `point_rewards_engine.go` | Local dup types | Phase 1 | Use domain types | backend |
+| `server/router/router.go` | Orphaned stub | Phase 1 | Delete; routing in `bootstrap/router.go` | backend |
+| Fake "Sales" template dashboard | Post-login landing | Phase 2 | Real member dashboard | frontend |
+| Billing/Profile placeholders | Template sample content | Phase 2–3 | Real or remove | frontend |
+| go-redis v8 | Sessions/cache | Phase 3 | Upgrade to v9 (context API change) | backend |
+
+---
+
+## 8. Risks Register
+
+| Risk | Phase | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| Points-ledger corruption during rules rewiring | 0–1 | Medium | Critical | Idempotency + reconciliation tests; dry-run on staging; rollback plan |
+| Leaked credentials already exploited (C1/C2) | 0 | Medium | Critical | Rotate immediately; audit registry/access logs |
+| Rule-engine performance at scale | 1–2 | Medium | High | Load test at 2× peak before launch |
+| Kafka activation destabilizes prod | 1 | Medium | Medium | Kafka fan-out only on sync path; `event_log` fallback (§3.5) |
+| Write-buffer path causes balance drift / out-of-order | 1 | Low | High | Partition Kafka by customer ID; idempotency keys; mark balances "pending" (§3.5) |
+| AI underperforms on thin data | 4 | High | Medium | Gate Phase 4 on min data-volume threshold (Phase 4 Data Requirements) |
+| Deferred regulation creates later liability | All | Medium | Medium | §9 accepted trade-off; double-entry audit trail built now (§3.9) |
+| Single-developer bus factor | All | High | High | Document runbooks/ADRs; keep changes small and reviewed |
+
+---
+
+## 9. Resolved Decisions (was Open Questions)
+
+All v1 open questions answered by the operator. Decisions are now reflected in §3 and the phases.
+
+| Question | Decision | Where Applied |
+|---|---|---|
+| Peak transaction volume? | **500 TPS** MVP target; load-test to 1,000 TPS | NFR §Phase 1, §3.4 |
+| `.env` creds reused in non-local envs? / secrets approach | **Adopt SOPS** secret manager; rotate any shipped creds | §3.4, §6.1, §7 |
+| n8n purpose? Temporal comparison? | **Temporal** = primary durable worker; **n8n** = low-code integration glue invoked from Temporal | §3.6, Phase 1 FR-1.4 |
+| Kafka for production? which events? | Yes — **transaction intermediary** + event fan-out for HA/burst; sync-authority default, opt-in write-buffer | §3.5, §3.2 |
+| Buy vs build voucher engine? | **Build in-house** | §3.1, Phase 2 |
+| Analytics warehouse? | **ClickHouse** | §3.8, Phase 3 |
+| Data residency? | **Indonesia-first**, design for later SEA multi-region | §3.9, §6.3 |
+| Phase 4 min data volume? | Proposed: ≥6mo history + ≥10k active members + ≥100k txns/tenant | Phase 4 Data Requirements |
+| Churn precision target? | Proposed: ≥0.70 precision @ ≥0.50 recall, beat recency heuristic | Phase 4 DoD |
+| Customer-facing or back-office only? | **Both — B2B2C**: B2B platform that powers clients' customer-facing experiences | §3.7 (multi-tenancy, dual API) |
+| Points legal classification? | **Defer regulation for MVP** (develop first); build double-entry audit trail now to avoid retrofit | §3.9, §6.3 |
+
+### 9.1 Resolved (v2.1)
+| Question | Decision | Where Applied |
+|---|---|---|
+| Temporal: self-host vs Temporal Cloud? | **Self-hosted**, in-cluster | §3.6, §3.9, Phase 1 |
+| Indonesia region / provider? | **K8s + Docker POC**, cloud-agnostic → promote to **EKS/GKE** later, no major refactor; Indonesia zone (e.g. GKE `asia-southeast2`) | §3.9 |
+| B2B2C member-auth model? | **Hybrid** — per-tenant local default + optional OIDC federation, `auth_source` per tenant | §3.10 |
+| ClickHouse managed vs self-host; retention? | **Self-hosted**, in-cluster; retention proposed 90d hot / 13mo raw / monthly aggregates (tune) | §3.8, §3.9 |
+
+### 9.2 Remaining Open Questions
+| Question | Blocks | Owner | Due |
+|---|---|---|---|
+| ClickHouse exact retention budget (confirm proposed 90d/13mo)? | Phase 3 storage sizing | Data/Infra | Before Phase 3 |
+| First federated client + IdP protocol (OIDC assumed; any SAML need)? | Phase 2/3 §3.10 | Eng/Product | When first SSO client lands |
+| Self-hosted Temporal persistence: PostgreSQL (reuse) vs Cassandra? | Phase 1 infra | Engineering | Before Phase 1 |
+
+---
+
+## 10. Glossary
+
+| Term | Definition |
+|---|---|
+| Earn | Any action that credits points to a balance |
+| Burn | Any action that debits points from a balance |
+| Idempotent | A transaction producing the same result whether submitted once or many times |
+| FR | Functional Requirement |
+| TPS | Transactions per second |
+| RFM | Recency, Frequency, Monetary — segmentation model |
+| Disposition | Per-feature decision: Keep / Improve / Add / Deprecate |
+| PointsLedger | Append-only earn/redeem record; balance = last entry per customer+program |
+| ProgramRule | Configurable earn rule — currently NOT applied to point math (fixed in Phase 1) |
+| RW / RR | Read-Write primary / Read-Replica connections |
+| Event bus / intermediary | Kafka — fan-out for events + opt-in write-buffer for high-burst ingestion (§3.5) |
+| Temporal | Durable workflow engine — retried/scheduled side effects (notifications, tier eval, expiry) |
+| n8n | Low-code integration tool — external SaaS glue, invoked from Temporal activities |
+| ClickHouse | Columnar OLAP store for analytics/dashboards; derived from the event stream |
+| SOPS | Secrets OPerationS — encrypts config at rest, decrypts into runtime env at deploy |
+| B2B2C | Business-to-business-to-consumer — we serve B2B clients and power their end-customer experiences |
+| Tenant | A business/client and its isolated data subtree (Merchant → Program → Customer) |
+
+---
+
+*End of TRD*


### PR DESCRIPTION
## Summary
Docs-only PR adding the product/architecture documentation set for the loyalty platform direction. No code changes.

## Contents
- **`docs/loyalty-platform-market-research.md`** — market landscape, feature catalogue, platform comparison matrix, UX patterns, build/buy/compose framework. Pricing & capabilities web-verified (Jun 2026); AI-synthesized claims flagged.
- **`docs/trd-loyalty-platform-v2.md`** — Technical Requirements Document (v2.1). Re-evaluated architecture: modular monolith + durable async edge (Kafka as transaction intermediary, self-hosted Temporal), ClickHouse analytics, B2B2C multi-tenancy, hybrid member-auth (local + OIDC), SOPS secrets, Indonesia-first K8s deploy, 500 TPS MVP. Phases 0–4.
- **`docs/product-analysis-v2.md`** — PRD bridging current codebase state → best-in-class, phased roadmap (MVP → Phase 5), measurable goals. Replaces the prior product-analysis.
- **`docs/prd/`** — one PRD per phase (MVP, Phase 1–5), problem-centric template: scope/non-goals, user stories + acceptance criteria, edge cases, dependencies.

## Review notes
- Decisions reflect answered open questions (500 TPS, self-hosted Temporal/ClickHouse, in-house voucher engine, hybrid auth, Indonesia-first, regulation deferred).
- `[PROPOSED]` tags mark features not yet evidenced in codebase or research.
- Phase 5 (coalition) is **gated** on a signed partner — not to be started speculatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)