### PR TITLE
docs: MVP sprint tech dev plans + github-issue skill

### DIFF
--- a/.claude/skills/github-issue/SKILL.md
+++ b/.claude/skills/github-issue/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: github-issue
+description: >
+  Register tasks from docs/trd/ as GitHub issues for go-loyalty-point, following
+  scrum/kanban convention: Epic (sprint) → User Story (task), with estimation
+  (high/med/low + story points), tagging (type/feature/fix/chore, component, phase,
+  sprint), and GitHub Project board fields. Use when the user says "register tasks",
+  "create issues from TRD", "file sprint N as issues", "open issue", or "/github-issue".
+---
+
+# GitHub Issue Management — go-loyalty-point
+
+Turns the per-sprint tech dev plans in `docs/trd/phase-*/sprint-*.md` into a tracked
+backlog of GitHub issues. Pairs with the `github-pr` skill (a PR `Closes #N`) and the
+`sdlc` agent (change-class flow).
+
+## 0. Prime Directive — Draft, don't auto-execute
+
+Adopted from `.claude/agents/sdlc.md`. **Never create, edit, or close a GitHub issue
+without explicit operator confirmation.** Parse the source, draft the issue(s), show
+them, then ask: *"Create these N issues, or revise?"* Wait for the word. Solo-operator
+project (Dandi) — you draft, Dandi decides.
+
+---
+
+## 1. Source → Issue Mapping (scrum/kanban)
+
+Source of truth = `docs/trd/<phase>/sprint-N.md`. Structure already matches agile:
+
+| TRD source element | GitHub object | Convention |
+|---|---|---|
+| `sprint-N.md` (whole file) | **Epic** issue | one per sprint; `type/epic` |
+| `## Task N.M — Title` | **User Story** issue | child of the epic; `type/*` by nature |
+| Sprint folder `phase-mvp/` | **Milestone** | `MVP`, `Phase 1`… maps to release |
+| `Type:` (backend/frontend/fullstack) | `component/*` label(s) | |
+| `Effort:` S/M/L | `size/*` + Estimate (SP) + Priority | §3 |
+| `Progress signal:` | Acceptance criterion #1 | testable, observable |
+| `Design` / `Implementation` / `Testing` | issue body sections | mandatory |
+| `Swagger:` line | Acceptance criterion (API registered) | |
+
+**Hierarchy is via task list + label, not GitHub sub-issues** (keep it portable):
+the Epic issue body holds a checklist linking each story (`- [ ] #NN Task 1.1 …`);
+each story body has `Epic: #<epic-number>`.
+
+Kanban columns (Project board Status field): `Backlog → Ready → In Progress → In Review → Done`, plus `Blocked`. New issues land in **Backlog**.
+
+---
+
+## 2. Label Taxonomy
+
+One-time bootstrap (see §7). Apply on every issue.
+
+### Type (exactly one)
+| Label | When |
+|---|---|
+| `type/epic` | Sprint container issue |
+| `type/feature` | New capability / user-facing behavior |
+| `type/fix` | Corrects a defect (e.g. C1–C4, S-findings) |
+| `type/chore` | Build/CI/infra/tooling, no product behavior |
+| `type/security` | P0/P1 security defect or hardening |
+| `type/test` | Test-coverage-only work |
+| `type/docs` | Docs/Swagger-only |
+
+### Change class (exactly one — mirrors sdlc + github-pr)
+`class:low` · `class:medium` · `class:high` · `class:hotfix`
+Default per effort: S→low/medium, M→medium, L→medium/high. Security defects ≥ `class:high`. If unsure, go higher.
+
+### Component (all that apply — go-loyalty-point pkg layout)
+`component/handler` · `component/service` · `component/repository` · `component/domain` ·
+`component/middleware` · `component/kafka` · `component/database` · `component/frontend` ·
+`component/ci` · `component/infra`
+Map from `Type:` → backend = service/repository/etc; frontend = `component/frontend`; fullstack = both.
+
+### Phase / Sprint
+`phase/mvp` · `phase/1` … `phase/5` — and — `sprint/0` … `sprint/5`
+
+### Size (story-point band — mirrors github-pr)
+`size/S` (1–2 SP) · `size/M` (3–5 SP) · `size/L` (8 SP) · `size/XL` (13 SP)
+
+### Estimation confidence (high/med/low — explicit per request)
+`est/low` · `est/med` · `est/high` — **effort confidence**, not size.
+Default: known refactor with file refs → `est/high`; new infra (Kafka, Temporal, SOPS) → `est/low`.
+
+### Special
+`blocked` · `adr-required` (story changes interfaces/contracts/migrations) · `good-first-task`
+
+### Effort → field defaults (one row, copy when drafting)
+| `Effort:` | `size/*` | Estimate SP | Priority | `est/*` default |
+|---|---|---|---|---|
+| S | `size/S` | 2 | Low/Medium | `est/high` |
+| M | `size/M` | 5 | Medium | `est/med` |
+| L | `size/L` | 8 | High | `est/low` |
+
+---
+
+## 3. Issue Templates
+
+### Epic (sprint)
+```markdown
+## Goal
+[copy sprint Goal]
+
+## Why now
+[copy sprint rationale]
+
+## Stories
+- [ ] #NN — Task N.1 …
+- [ ] #NN — Task N.2 …
+(filled after child issues created)
+
+## Definition of Done (sprint)
+[copy sprint DoD checklist]
+
+## Source
+docs/trd/<phase>/sprint-N.md
+
+## Meta
+Milestone: <MVP|Phase k> · Sprint: N · Depends on: sprint N-1
+```
+Labels: `type/epic`, `phase/*`, `sprint/N`, `class:*` (highest among children).
+
+### User Story (task)
+```markdown
+## Story
+As a [member|operator|platform], I want [capability], so that [value].
+(derive from PRD user story if the task maps to one; else state the engineering outcome)
+
+## Design
+[copy task Design]
+
+## Implementation
+[copy task Implementation — keep file refs, e.g. Dockerfile:37, error_handler.go:116]
+
+## Testing plan
+[copy task Testing]
+
+## Acceptance criteria
+- [ ] [Progress signal — the observable outcome]
+- [ ] Design + implementation done as specified
+- [ ] Tests added; `go test -race ./...` green
+- [ ] [Swagger: endpoints registered via `swag init -g main.go`]  ← only if API
+- [ ] Tenant isolation respected (no cross-tenant read/write)
+
+## Estimation
+Effort: <S|M|L> · Story points: <2|5|8> · Confidence: <low|med|high>
+
+## Epic
+Epic: #<epic-number>
+
+## Source
+docs/trd/<phase>/sprint-N.md → Task N.M
+
+## Change class
+<low|medium|high> — [1-sentence justification]
+```
+Labels: `type/*`, `class:*`, `component/*`, `phase/*`, `sprint/N`, `size/*`, `est/*`,
+`adr-required` if it touches interfaces/contracts/migrations.
+
+---
+
+## 4. Workflow
+
+1. **Read the source.** Confirm which sprint(s): "All of phase-mvp, or sprint N?"
+2. **Parse tasks.** For each `## Task N.M`, extract Title, Type, Effort, Progress signal, Design, Implementation, Testing, Swagger.
+3. **Draft the Epic** + one Story per task, applying §2 labels and §3 templates. Compute size/SP/priority/est from the Effort row in §2.
+4. **Present drafts** (titles + labels + estimation table). Ask: *"Create these N issues, or revise?"*
+5. **On confirmation:** create Epic first (capture its number), then Stories with `Epic: #N`, then edit the Epic body to fill the `## Stories` checklist with real issue numbers.
+6. **Link to Project board** (§5–6, reuse github-pr machinery): add each issue, set Status=Backlog, Priority, Size, Estimate.
+7. **Report** the created issue numbers + board link.
+
+**Title convention:** `<type>(<sprint-scope>): <task title>` —
+e.g. `feat(s1): wire rule engine into earn path`, `fix(s0): remove .env from Docker image`.
+
+---
+
+## 5. Create Commands
+
+```bash
+# Epic
+gh issue create \
+  --title "epic(s<N>): <sprint theme>" \
+  --assignee dydanz \
+  --milestone "<MVP|Phase k>" \
+  --label "type/epic,phase/mvp,sprint/<N>,class:<...>" \
+  --body-file <drafted-epic-body.md>
+
+# Story (repeat per task)
+gh issue create \
+  --title "<type>(s<N>): <task title>" \
+  --assignee dydanz \
+  --milestone "<MVP|Phase k>" \
+  --label "type/<...>,class:<...>,component/<...>,phase/mvp,sprint/<N>,size/<...>,est/<...>" \
+  --body-file <drafted-story-body.md>
+
+# After stories exist, fill the epic checklist
+gh issue edit <EPIC_N> --body-file <updated-epic-body.md>
+```
+
+Use `--body-file` with a temp file in the scratchpad dir (avoids heredoc-escaping issues
+with multi-line Design/Implementation blocks).
+
+---
+
+## 6. Link to GitHub Project + Set Fields
+
+Reuse the field-ID machinery from `.claude/skills/github-pr/SKILL.md` §4–5 (same project,
+same `${go-loyalty-point_*}` env vars). After creating each issue:
+
+```bash
+# Add to board
+gh project item-add ${go-loyalty-point_PROJECT_NUM} --owner dydanz \
+  --url "$(gh issue view <N> --json url -q .url)"
+
+# Get item id, then set fields (Status=Backlog, Priority, Size, Estimate)
+gh project item-edit --project-id ${go-loyalty-point_PROJECT_ID} --id <ITEM_ID> \
+  --field-id ${go-loyalty-point_FIELD_ESTIMATE} --number <SP>
+# Priority / Size / Status → single-select-option-id (see github-pr §5 for option IDs)
+```
+
+If project env vars are not set, run the one-time discovery in `github-pr` §5 first, or
+skip board linking and tell the operator labels-only was applied.
+
+---
+
+## 7. One-Time Label Bootstrap
+
+Run once per repo. Idempotent-ish (`|| true` to ignore "already exists").
+
+```bash
+# Type
+for t in epic:6f42c1 feature:1d76db fix:d73a4a chore:cfd3d7 security:b60205 test:fbca04 docs:0075ca; do
+  gh label create "type/${t%%:*}" --color "${t##*:}" --force; done
+# Class
+gh label create "class:low"    --color c2e0c6 --force
+gh label create "class:medium" --color fbca04 --force
+gh label create "class:high"   --color d73a4a --force
+gh label create "class:hotfix" --color b60205 --force
+# Component
+for c in handler service repository domain middleware kafka database frontend ci infra; do
+  gh label create "component/$c" --color 0366d6 --force; done
+# Phase + sprint
+for p in mvp 1 2 3 4 5; do gh label create "phase/$p" --color 5319e7 --force; done
+for s in 0 1 2 3 4 5; do gh label create "sprint/$s" --color bfd4f2 --force; done
+# Size + estimation confidence
+gh label create "size/S" --color c2e0c6 --force; gh label create "size/M" --color fbca04 --force
+gh label create "size/L" --color e99695 --force; gh label create "size/XL" --color d73a4a --force
+gh label create "est/low" --color ededed --force; gh label create "est/med" --color d4c5f9 --force
+gh label create "est/high" --color 0e8a16 --force
+# Special
+gh label create "blocked" --color 000000 --force
+gh label create "adr-required" --color 5319e7 --force
+gh label create "good-first-task" --color 7057ff --force
+```
+
+Milestones (one-time):
+```bash
+for m in MVP "Phase 1" "Phase 2" "Phase 3" "Phase 4" "Phase 5"; do
+  gh api repos/:owner/:repo/milestones -f title="$m" 2>/dev/null || true; done
+```
+
+---
+
+## 8. Guardrails
+
+- **Confirm before any `gh issue create/edit/close`** (Prime Directive).
+- **No duplicates:** before creating, `gh issue list --search "<task title> in:title"`; if a match exists, ask whether to update instead.
+- **One Epic per sprint.** If the epic already exists, attach new stories to it, don't recreate.
+- **`adr-required`** on any story touching interfaces, session/event contracts, or DB migrations (mirrors sdlc Phase 4).
+- **Security defects** (C1–C4) → `type/security` + `class:high` minimum, even if effort is S.
+- **Acceptance criteria must be testable** — the Progress signal is criterion #1; if a task lacks one, derive an observable check before filing.
+- Keep file references intact (e.g. `Dockerfile:37`) — they make the issue actionable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,8 @@ This project follows a lightweight multi-phase SDLC. Full agent: `.claude/agents
 | `class:high` | TRD in issue / doc | Self-approval + 2nd review | Full suite + manual | `feature/<id>-slug` |
 | `class:hotfix` | Skip; post-merge ≤24h | Self-approval + smoke | Smoke | `hotfix/<id>-slug` |
 
+**Issue creation skill:** `.claude/skills/github-issue/SKILL.md` — invoke via `/github-issue` or say "register tasks" / "create issues from TRD". Turns `docs/trd/<phase>/sprint-*.md` into a tracked backlog: Epic (sprint) → User Story (task), with estimation (size + story points + confidence), tagging (`type/*`, `class:*`, `component/*`, `phase/*`, `sprint/*`), and Project board fields. Draft-only — confirm before any `gh issue` write.
+
 **PR creation skill:** `.claude/skills/github-pr/SKILL.md` — invoke via `/github-pr` or say "create PR".
 
 ---

--- a/docs/trd/phase-mvp/README.md
+++ b/docs/trd/phase-mvp/README.md
@@ -1,0 +1,43 @@
+# TRD — Phase MVP: Sprint Tech Dev Plans
+
+Per-sprint technical development plans for the **MVP (Core Earn & Burn Loop)**.
+
+**Sources:**
+- PRD: [`docs/prd/prd-mvp-core-earn-burn.md`](../../prd/prd-mvp-core-earn-burn.md)
+- TRD: [`docs/trd-loyalty-platform-v2.md`](../../trd-loyalty-platform-v2.md) — Phase 0 (§5) + Phase 1 (§5) + architecture §3
+- Code analysis: [`docs/code-analysis-20260623.md`](../../code-analysis-20260623.md)
+
+**Cadence:** 2-week sprints. Ordering by **dependency, not value** — security + correctness foundations precede the member-facing surface. Tenant scoping threads through from Sprint 1.
+
+---
+
+## Sprint Index
+
+| Sprint | Theme | TRD anchor | Gate |
+|---|---|---|---|
+| [Sprint 0](./sprint-0.md) | Stabilize & Secure | TRD Phase 0 (C1–C4, S8) | **Hard gate — blocks all release** |
+| [Sprint 1](./sprint-1.md) | Rule Engine + Money-Path Tests | FR-1.2, S1 | Depends on S0 |
+| [Sprint 2](./sprint-2.md) | Ledger Integrity + Idempotency | FR-1.1, FR-1.3, §3.5 | Depends on S1 |
+| [Sprint 3](./sprint-3.md) | Tenant Scoping + Real-Time Events | FR-1.4, §3.7, §3.5 | Depends on S2 |
+| [Sprint 4](./sprint-4.md) | Member Surface + Email | PRD §5.A | Depends on S3 |
+| [Sprint 5](./sprint-5.md) | Observability + Launch Readiness | §6.2, NFR | Depends on S4 |
+
+## Definition of Done (every story)
+
+- Code merged + `go test -race ./...` green in CI
+- Tenant isolation respected (no cross-tenant read/write)
+- Observable: error paths logged via `LogError`; key paths metered
+- Parameterized SQL only; migrations append-only
+- No secrets in code/image
+
+## Sequencing Notes
+
+- **Sprint 0 is a hard gate.** P0 security defects (§2.3 C1–C4) make the system unsafe to build on. Nothing member-facing ships before it.
+- **Sprints 1–3 are backend-only** — no UI dependency; runnable by a small backend team.
+- **UX wireframes** (member balance/redeem widget, operator ledger view) start in parallel during S0–S1 and lock the Sprint 4 API contract.
+- **Open Questions** must close before the sprint that needs them: email provider + starting-balance policy (S4); points-liability accounting stance (S5); Temporal persistence choice — PostgreSQL vs Cassandra (S3, TRD §9.2).
+- Compressible to ~4 sprints if S2 + S3 parallelize across two engineers.
+
+## Scope boundary (MVP non-goals — do NOT build here)
+
+No-code rule builder UI · tiers · voucher campaigns · points expiry · gamification · partner/coalition · AI · OIDC federation (local auth only) · real-time analytics dashboards · native mobile SDK. See PRD §4.

--- a/docs/trd/phase-mvp/sprint-0.md
+++ b/docs/trd/phase-mvp/sprint-0.md
@@ -1,0 +1,128 @@
+# Sprint 0 — Stabilize & Secure
+
+> **Phase:** MVP · **Duration:** 2 weeks · **TRD anchor:** Phase 0 (§5), §2.3 C1–C4 + S8, §6.1
+> **Gate:** HARD — published build is unsafe until this lands. No member-facing work ships before sign-off.
+
+## Goal
+
+Make the system safe to build on. Kill the P0 security defects, stop silent error-swallowing, give CI teeth (`-race` + vuln scan).
+
+## Why first
+
+§2.3 lists four 🔴 Critical defects: creds in the published image, a public endpoint leaking bcrypt hashes, an unimplemented `LogError` swallowing all 5xx, a startup routine wiping every Redis session. Fix before building anything.
+
+**Out of scope:** rule engine, ledger, member UI.
+
+---
+
+## Task 0.1 — Secrets out of image (SOPS)
+
+**Type:** backend / infra · **Effort:** M · **TRD:** C1, §3.4, §6.1, §7
+**Progress signal:** `docker run --rm <img> cat /app/.env` fails — image provably clean.
+
+**Design**
+- Threat: any image puller reads DB/Redis creds. Remove secrets from build context; inject at runtime only.
+- Choose SOPS with `age` key (POC simplicity; KMS later). One encrypted file per env (`config/secrets.<env>.enc.yaml`), decrypted into env / K8s Secrets at deploy.
+
+**Implementation**
+- Remove `.env` COPY from `Dockerfile` (TRD cites `Dockerfile:37`); add `.env` to `.dockerignore`.
+- Add SOPS encrypted config + decrypt step in deploy/entrypoint; app reads from env (`pkg/config`).
+- **Rotate every credential** shipped in a published image (DB, Redis); audit GHCR pull logs if available.
+
+**Testing**
+- Image test (CI): assert `.env` absent and no plaintext secret strings in layers.
+- Boot test: app starts from injected env only (no `.env` file present).
+- Negative: missing required secret → fail-fast with clear error (per CLAUDE.md config rule).
+
+---
+
+## Task 0.2 — Remove hash-leak endpoint
+
+**Type:** backend · **Effort:** S · **TRD:** C2
+**Progress signal:** `/api/auth/test/random-user` returns 404; no bcrypt hash retrievable unauthenticated.
+
+**Design**
+- Endpoint (`internal_load_test_handler.go` `GetRandomVerifiedUser`) exposes password hashes for offline cracking. Prefer outright removal for MVP; if load-test fixture needed, internal-gate + drop password field.
+
+**Implementation**
+- Delete route registration + handler. Remove now-dead repo method if unused.
+
+**Testing**
+- Integration: route returns 404.
+- Grep/contract test: no handler returns a `password`/hash field in any response body.
+
+---
+
+## Task 0.3 — Stop startup session-wipe
+
+**Type:** backend · **Effort:** S · **TRD:** C4
+**Progress signal:** live session token still valid after a rolling restart.
+
+**Design**
+- `DeleteAllSession` at boot (TRD cites `cmd/api/main.go:76`) force-logs-out all users on every deploy. Remove; rely on Redis TTL for expiry.
+
+**Implementation**
+- Remove the startup call. Confirm session TTL set on write.
+
+**Testing**
+- Restart test: create session → restart process → assert token still authenticates.
+
+---
+
+## Task 0.4 — Implement `LogError`
+
+**Type:** backend · **Effort:** S · **TRD:** C3, §6.2
+**Progress signal:** triggered 5xx appears as structured JSON log with trace id + route.
+
+**Design**
+- Stub at `server/util/error_handler.go:116` swallows 5xx → zero prod visibility. Replace with structured zerolog emit (level=error; fields: correlation id, route, status, err). Every 5xx in the HTTP mapper routes through it.
+
+**Implementation**
+- Implement `LogError`; wire into the error mapper for all 5xx mappings.
+
+**Testing**
+- Unit: `LogError` emits expected fields (capture zerolog output).
+- Integration: forced handler panic/5xx produces one structured error log.
+
+---
+
+## Task 0.5 — CI hardening (`-race` + `govulncheck`)
+
+**Type:** infra · **Effort:** S · **TRD:** §6.5
+**Progress signal:** CI fails red on an injected data race or a known vuln.
+
+**Design**
+- CI runs `go test` without `-race` (S-level finding) → races invisible. Add `-race` + `govulncheck`, block on High/Critical.
+
+**Implementation**
+- Edit `.github/workflows/go.yml`: `go test -race ./...`; add `govulncheck ./...` step.
+
+**Testing**
+- Sanity: temporary race in a branch makes CI red; revert.
+- `govulncheck` clean on main.
+
+---
+
+## Sprint 0 — Definition of Done
+
+- [ ] Zero known P0 defects; rotated creds for anything shipped in a published image.
+- [ ] Image contains no secrets (verified command fails).
+- [ ] Hash-leak endpoint removed/gated + password field dropped.
+- [ ] `LogError` implemented; 5xx emit structured logs.
+- [ ] `go test -race ./...` + `govulncheck` green in CI.
+- [ ] Sessions survive rolling restart.
+
+## Swagger
+
+No new public API. **Action:** regenerate `swag init -g main.go` after removing the test endpoint so docs no longer advertise it; enforce swagger-up-to-date in CI.
+
+## Risks
+
+| Risk | L | I | Mitigation |
+|---|---|---|---|
+| Creds already leaked via published image | M | Critical | Rotate all C1/C2 creds; audit pull logs |
+| SOPS slows deploy | M | Med | Single encrypted env file first |
+
+## Dependencies
+
+Blocks every later sprint. No upstream dependency. Decide SOPS key backend (age for POC).

--- a/docs/trd/phase-mvp/sprint-1.md
+++ b/docs/trd/phase-mvp/sprint-1.md
@@ -1,0 +1,110 @@
+# Sprint 1 — Rule Engine + Money-Path Tests
+
+> **Phase:** MVP · **Duration:** 2 weeks · **TRD anchor:** FR-1.2, S1 (§2.3), §3.3 principle 3
+> **Depends on:** Sprint 0 complete.
+
+## Goal
+
+Earn computed by the **real rule engine**, not hardcoded constants. Money paths (`TransactionService.Create`, `RedemptionService.Create`) get real test coverage so the loop is trustworthy.
+
+## Why now
+
+§2.3 S1: the rules engine (`point_rewards_engine.go`) is dead code; `transaction_service.go` uses hardcoded math — the core differentiator is a façade. §2.4: money paths have zero tests. Wire + cover before adding ledger guarantees.
+
+**Out of scope:** idempotency/concurrency (Sprint 2), events (Sprint 3), member UI (Sprint 4).
+
+---
+
+## Task 1.1 — Wire rule engine into earn path
+
+**Type:** backend · **Effort:** L · **TRD:** FR-1.2
+**Progress signal:** same transaction under two different active rules yields two different point totals.
+
+**Design**
+- `TransactionService.Create` must consult active `ProgramRule`s via the rewards engine for every earn. Fetch rules through `ProgramRuleRepository.GetActiveRules(programID)`; pass domain `Transaction` + rules into `calculatePoints`/`evaluateRule`. Rule precedence + no-matching-rule fallback (0 or program default) defined explicitly.
+
+**Implementation**
+- Inject `ProgramRuleRepository` into `TransactionService` (constructor DI — no global state).
+- Replace hardcoded constant computation with engine call.
+- Handle: no active rule, multiple matching rules (precedence), rule references missing field.
+
+**Testing**
+- Unit (table-driven): amount/type/category inputs × rules → expected points.
+- Regression: fixture transaction + rule A vs rule B → different totals (the FR-1.2 DoD test).
+- Edge: zero amount; no active rule; overlapping rules.
+
+**Swagger:** earn endpoint (`POST /v1/transactions`) response schema unchanged in shape, but document that `points_earned` is rule-derived; regenerate swag.
+
+---
+
+## Task 1.2 — Delete shadow types
+
+**Type:** backend · **Effort:** S · **TRD:** FR-1.2, S1
+**Progress signal:** engine compiles against domain types only; duplicate types gone, tests still green.
+
+**Design**
+- `point_rewards_engine.go` defines local shadow `Transaction`/`Program`/`ProgramRule` duplicating domain types — bug source. Engine must use `pkg/domain` types.
+
+**Implementation**
+- Remove shadow types; update engine signatures to domain types; fix call sites.
+
+**Testing**
+- Compilation + existing engine tests pass against domain types.
+- No remaining references to shadow types (grep guard in review).
+
+---
+
+## Task 1.3 — Test coverage: `TransactionService.Create`
+
+**Type:** backend · **Effort:** M · **TRD:** §2.4 S8, §6.5 (≥80%)
+**Progress signal:** coverage report ≥80% on the service; CI gate green.
+
+**Design**
+- Use existing testify/suite template (`points_service_test.go` style) + mocks from `pkg/mocks`. Cover earn happy path, rule-driven amounts, error mapping (typed domain errors).
+
+**Implementation**
+- Tests with mocked repos; assert ledger insert called with engine-computed amount; assert typed errors propagate (not swallowed).
+
+**Testing (self)**
+- `go test -race -cover` ≥80% on `TransactionService`.
+
+---
+
+## Task 1.4 — Test coverage: `RedemptionService.Create`
+
+**Type:** backend · **Effort:** M · **TRD:** FR-1.3, §2.4 S8
+**Progress signal:** redeem coverage ≥80%; failed-redeem-deducts-nothing test passes.
+
+**Design**
+- FR-1.3: validate balance before commit; failed redemption deducts nothing; rollback atomic. (Full concurrency in Sprint 2; here cover logical correctness.)
+
+**Implementation**
+- Tests: sufficient balance → deduct; insufficient → reject with typed error, no deduction; mid-failure → rollback.
+
+**Testing (self)**
+- `go test -race -cover` ≥80% on `RedemptionService`.
+
+---
+
+## Sprint 1 — Definition of Done
+
+- [ ] Earn 100% computed by rule engine; hardcoded constants removed.
+- [ ] Regression proves rule change → point change.
+- [ ] Shadow types deleted; engine uses domain types.
+- [ ] Both money services ≥80% coverage; `go test -race` green.
+- [ ] Swagger regenerated.
+
+## Swagger
+
+`POST /v1/transactions` (earn) and `POST /v1/redemptions` (redeem) documented with request/response schemas + typed error codes. `swag init -g main.go`; CI enforces up-to-date.
+
+## Risks
+
+| Risk | L | I | Mitigation |
+|---|---|---|---|
+| Rules wiring regresses ledger correctness | M | Critical | Regression + reconciliation tests before merge |
+| Hidden hardcoded paths remain | M | High | Grep for constant math; assert via rule-change test |
+
+## Dependencies
+
+S0 (CI `-race`, `LogError`). Rule model assumed present in DB (TRD: already modeled). Frontend not involved.

--- a/docs/trd/phase-mvp/sprint-2.md
+++ b/docs/trd/phase-mvp/sprint-2.md
@@ -1,0 +1,127 @@
+# Sprint 2 — Ledger Integrity + Idempotency
+
+> **Phase:** MVP · **Duration:** 2 weeks · **TRD anchor:** FR-1.1, FR-1.3, §3.3 principles 1–2, §3.5
+> **Depends on:** Sprint 1 complete.
+
+## Goal
+
+Ledger never double-awards on retry, never drifts negative under concurrency, and reverses refunds cleanly. **The single most critical risk in the whole program is ledger data integrity (TRD §1)** — this sprint owns it.
+
+## Why now
+
+Engine wired (S1) → now make the ledger trustworthy under real-world retries and concurrent access before exposing it to members (S4).
+
+**Out of scope:** events/Kafka (Sprint 3), Kafka write-buffer path (later phase).
+
+---
+
+## Task 2.1 — Idempotency key on earn
+
+**Type:** backend · **Effort:** M · **TRD:** FR-1.1, §3.3 principle 2, §3.5
+**Progress signal:** resubmitting the same transaction ID twice yields one ledger entry, one balance change.
+
+**Design**
+- Two-layer dedupe: Redis key (fast) + **unique DB constraint** on transaction ID (authoritative). Extend the existing atomic CTE insert. Client supplies transaction ID. Same ID = no-op returning the original result.
+
+**Implementation**
+- Migration: unique constraint on `(tenant_id, transaction_id)` in the ledger table (append-only migration).
+- Redis idempotency check before insert; on unique-violation, fetch + return original entry (idempotent response, not error).
+
+**Testing**
+- Sequential resubmit → identical response, single entry.
+- Redis-miss + DB-hit path (simulate Redis eviction) → still deduped by DB constraint.
+
+**Swagger:** document `transaction_id` as required idempotency key on `POST /v1/transactions`; note resubmit semantics (same result, no double credit).
+
+---
+
+## Task 2.2 — Idempotency under concurrency
+
+**Type:** backend · **Effort:** M · **TRD:** FR-1.2 (concurrent), §6.5 race
+**Progress signal:** N concurrent identical submits → exactly one credit (race test green).
+
+**Design**
+- Concurrent same-txn submits must not both insert. Rely on DB unique constraint as the serialization point; CTE insert stays atomic.
+
+**Implementation**
+- Ensure insert path handles unique-violation as success-dedupe under contention.
+
+**Testing**
+- `go test -race`: spawn goroutines submitting same txn ID; assert one entry, correct balance.
+
+---
+
+## Task 2.3 — Atomic redemption + double-spend guard
+
+**Type:** backend · **Effort:** M · **TRD:** FR-1.3, PRD §6 (double-spend)
+**Progress signal:** two concurrent redeems on one balance → one succeeds, one fails "Insufficient Balance", no negative drift.
+
+**Design**
+- Balance validated before commit; deduction atomic via DB locking + idempotency. Second concurrent redeem fails cleanly.
+
+**Implementation**
+- Row-lock / atomic CTE on redeem; reject when insufficient; failed redeem deducts nothing.
+
+**Testing**
+- Race test: two devices/tabs redeem same balance → exactly one success.
+- Assert balance never goes negative on the redeem path.
+
+---
+
+## Task 2.4 — Refund / reversal as compensating entry
+
+**Type:** backend · **Effort:** M · **TRD:** FR-1.1, PRD §6 (refund)
+**Progress signal:** refund after earn produces a compensating ledger entry; balance may go negative; fully audited.
+
+**Design**
+- Refund reverses the original earn as a new compensating entry (not a mutation — ledger is append-only). Atomic + audited. Balance may go negative until re-earned.
+
+**Implementation**
+- Reversal entry references original txn ID; source = refund. Idempotent on refund ID.
+
+**Testing**
+- Earn → refund → balance reflects reversal; original entry untouched.
+- Double refund of same refund ID → single reversal (idempotent).
+
+**Swagger:** `POST /v1/transactions/{id}/refund` (or reversal event) documented.
+
+---
+
+## Task 2.5 — Immutable ledger entry shape
+
+**Type:** backend · **Effort:** S · **TRD:** FR-1.1, glossary PointsLedger
+**Progress signal:** every entry carries delta, source, txn ID, resulting balance, timestamp; none mutable.
+
+**Design**
+- Append-only; balance = last entry per customer+program. Entry immutable after write.
+
+**Implementation**
+- Confirm/lock schema fields; no UPDATE paths on ledger rows.
+
+**Testing**
+- Contract test: entry has all required fields; attempt to mutate is not exposed.
+
+---
+
+## Sprint 2 — Definition of Done
+
+- [ ] Resubmit same txn ID = no-op (Redis + unique DB constraint), verified under concurrency.
+- [ ] Concurrent redeem cannot double-spend or drift negative.
+- [ ] Refund reverses atomically as a compensating, audited entry.
+- [ ] Ledger entries immutable with full required fields.
+- [ ] PRD §6 edge cases (double-spend, retry-dup, refund) covered by `-race` tests.
+
+## Swagger
+
+`POST /v1/transactions` (idempotency key documented), `POST /v1/redemptions`, refund/reversal endpoint — all regenerated via `swag init`. Error responses (insufficient balance, duplicate) documented with codes.
+
+## Risks
+
+| Risk | L | I | Mitigation |
+|---|---|---|---|
+| Balance corruption during constraint rollout | M | Critical | Reconciliation test on staging; rollback plan; dry-run migration |
+| Redis/DB dedupe divergence | L | High | DB constraint is authoritative; Redis is optimization only |
+
+## Dependencies
+
+S1 (engine produces the amount being credited). No frontend. Migration must be append-only (CLAUDE.md hard rule).

--- a/docs/trd/phase-mvp/sprint-3.md
+++ b/docs/trd/phase-mvp/sprint-3.md
@@ -1,0 +1,125 @@
+# Sprint 3 — Tenant Scoping + Real-Time Events
+
+> **Phase:** MVP · **Duration:** 2 weeks · **TRD anchor:** FR-1.4, §3.7, §3.5, §3.3 principle 5
+> **Depends on:** Sprint 2 complete.
+
+## Goal
+
+Every record, query, cache key, and event is **tenant-scoped** — a B2B2C surface cannot leak one client's members to another. Earn/burn fans out in real time via Kafka, with a PostgreSQL `event_log` fallback so the bus is never a hard dependency.
+
+## Why now
+
+Ledger is correct (S2). Before exposing it to members (S4), enforce isolation and stand up the real-time event path the member dashboard's "<2s" requirement needs.
+
+**Out of scope:** Kafka write-buffer / 202 ingestion (later phase — MVP uses sync-authority path only), notifications UI.
+
+---
+
+## Task 3.1 — `tenant_id` on every record + query
+
+**Type:** backend · **Effort:** L · **TRD:** §3.7
+**Progress signal:** all ledger/member/transaction reads + writes filtered by `tenant_id`; no unscoped query remains.
+
+**Design**
+- Tenant tree: business/client → Merchant → Program → Customer. Add `tenant_id` propagated through auth claims into every repository call and cache key. Single source: token claim, not request param.
+
+**Implementation**
+- Migration: ensure `tenant_id` column + index on member/transaction/ledger tables (append-only).
+- Thread `tenant_id` through service → repository signatures; scope cache keys (`{tenant}:...`).
+
+**Testing**
+- Repository tests assert WHERE `tenant_id` present on every query.
+- Seed two tenants; assert queries return only own-tenant rows.
+
+---
+
+## Task 3.2 — `TenantScope` middleware + isolation tests
+
+**Type:** backend · **Effort:** M · **TRD:** §3.7, §6.5 (tenant isolation mandatory)
+**Progress signal:** integration test: member of tenant A gets 403/empty on tenant B data.
+
+**Design**
+- Middleware extracts `tenant_id` from the validated token, injects into request context; services read it from context, never from client input.
+
+**Implementation**
+- Add `TenantScope` to the middleware chain (after Auth). Reject/zero cross-tenant access.
+
+**Testing**
+- **Mandatory isolation test (§6.5):** tenant A token cannot read tenant B member/ledger — asserted in integration suite. This test is a release gate.
+
+**Swagger:** document that all `/v1/*` endpoints are tenant-scoped via bearer token; no `tenant_id` request param accepted.
+
+---
+
+## Task 3.3 — Emit `points.committed` to Kafka
+
+**Type:** backend · **Effort:** L · **TRD:** FR-1.4, §3.5 (sync-authority path)
+**Progress signal:** earn/burn produces a Kafka event within 2s carrying tenant id, delta, new balance, txn ref.
+
+**Design**
+- Sync-authority model: commit ledger to PostgreSQL **synchronously**, then publish `points.committed` for fan-out. Payload: tenant id, points delta, new balance, transaction reference, trigger event type. Event key = customer id (ordering).
+
+**Implementation**
+- Wire kafka-go producer (currently imported, unused) in `pkg/channel`/`pkg/kafka`; publish after successful ledger commit.
+
+**Testing**
+- Integration with embedded/test Kafka: earn → event observed <2s with correct payload + tenant scoping.
+
+---
+
+## Task 3.4 — `event_log` fallback when bus down
+
+**Type:** backend · **Effort:** M · **TRD:** FR-1.4, §3.5 (failure handling), PRD §6
+**Progress signal:** with Kafka stopped, earn still commits; event lands in PostgreSQL `event_log`, replays when bus returns.
+
+**Design**
+- Kafka is fan-out, **not** a hard dependency on the sync path. On publish failure, write the event to PostgreSQL `event_log`; a replayer drains it when Kafka recovers.
+
+**Implementation**
+- `event_log` table (append-only migration); fallback write on producer error; replay worker.
+
+**Testing**
+- Kill Kafka in test → earn succeeds, row in `event_log`; restart Kafka → row replayed, marked done.
+
+---
+
+## Task 3.5 — Per-tenant member auth (`auth_source = local`)
+
+**Type:** backend · **Effort:** M · **TRD:** §3.10 (local only for MVP)
+**Progress signal:** same email registers independently under two tenants; tokens are tenant-scoped.
+
+**Design**
+- MVP = **local auth only** (federation deferred). Member credentials scoped to `tenant_id`; same email can exist per tenant. Issue tenant-scoped member token consumed by `/v1/member/*`.
+
+**Implementation**
+- Member auth keyed by `(tenant_id, email)`; token carries `tenant_id` + member id.
+
+**Testing**
+- Register email under tenant A and B → two distinct members; cross-tenant token rejected.
+
+**Swagger:** `POST /v1/member/auth/login`, `/register` documented (tenant resolved from context/subdomain, not body).
+
+---
+
+## Sprint 3 — Definition of Done
+
+- [ ] `tenant_id` on every record/query/cache key/event.
+- [ ] `TenantScope` middleware live; mandatory isolation test green (release gate).
+- [ ] `points.committed` emitted <2s on earn/burn with correct payload.
+- [ ] Kafka outage → sync commit still succeeds; `event_log` fallback + replay verified.
+- [ ] Local per-tenant member auth working; 0 cross-tenant identity leaks.
+
+## Swagger
+
+All `/v1/*` marked tenant-scoped (bearer). Member auth endpoints registered. Event payloads documented in an async/events appendix (not REST, but record the contract). `swag init -g main.go`.
+
+## Risks
+
+| Risk | L | I | Mitigation |
+|---|---|---|---|
+| Missed unscoped query leaks cross-tenant | M | Critical | Isolation test as gate; repo-level review for WHERE tenant_id |
+| Kafka activation destabilizes commit path | M | Med | Fan-out only; `event_log` fallback (§3.5) |
+
+## Dependencies
+
+S2 (ledger commit is the event trigger). Temporal **not** required this sprint (notification workflow deferred to Phase 1 proper / Sprint 4 email). Open question (TRD §9.2): Temporal persistence choice — not blocking MVP.

--- a/docs/trd/phase-mvp/sprint-4.md
+++ b/docs/trd/phase-mvp/sprint-4.md
@@ -1,0 +1,142 @@
+# Sprint 4 — Member Surface + Email
+
+> **Phase:** MVP · **Duration:** 2 weeks · **TRD anchor:** PRD §5.A, §3.7 (member API + SDK), FR-1.4 (notification)
+> **Depends on:** Sprint 3 complete.
+
+## Goal
+
+Member can join, see balance + ledger, and redeem — through a thin embeddable surface. Transactional email reliable (OTP + earn/redeem confirmation). First sprint with **frontend**.
+
+## Why now
+
+Backend correct, isolated, real-time (S0–S3). Now expose the loop. UI is thin: wireframes (started in parallel during S0–S1) lock the API contract built here.
+
+**Out of scope:** no-code rule builder, tiers, dashboards, native mobile (all post-MVP).
+
+**Blocker before start:** email provider selection + starting-balance policy (Open Questions) must be closed. Redeem-tap flow depends on POS/checkout integration model — settle first.
+
+---
+
+## Task 4.1 — Enrollment + optional welcome balance
+
+**Type:** backend · **Effort:** M · **TRD:** PRD §5.A Enrollment
+**Progress signal:** new member created under correct tenant; optional starting balance applied; confirmation email sent.
+
+**Design**
+- Member created under `tenant_id` (from S3.5 auth context). Optional welcome balance per program config → seeds an earn ledger entry (rule-engine or config-driven). Confirmation email queued.
+
+**Implementation**
+- `POST /v1/member/enroll`: create member, apply starting balance as a ledger entry (idempotent), trigger confirmation email.
+
+**Testing**
+- Enroll → member under correct tenant; starting balance = config; email enqueued.
+- Edge: enroll without welcome-balance config → 0 balance, no spurious entry.
+
+**Swagger:** `POST /v1/member/enroll` request/response + error codes registered.
+
+---
+
+## Task 4.2 — Transactional email (OTP + confirmations)
+
+**Type:** backend · **Effort:** M · **TRD:** PRD §5.A, §3.6 (Temporal/n8n delivery), PRD §6 (OTP not delivered)
+**Progress signal:** OTP email arrives; "resend code" works; earn/redeem send confirmation.
+
+**Design**
+- Reliable delivery via selected provider; route through Temporal activity (durable retry) or n8n integration. OTP for enrollment/login; confirmations on earn/redeem. "Resend code" so enrollment never silently stuck.
+
+**Implementation**
+- Email service abstraction + provider adapter; OTP issue/verify; confirmation hooks on `points.committed`.
+
+**Testing**
+- OTP delivered + verifies; resend issues a fresh valid code; undelivered → resend path, not stuck.
+- Confirmation fires on earn and redeem.
+
+**Swagger:** `POST /v1/member/auth/otp/request`, `/otp/verify`, `/otp/resend` registered.
+
+---
+
+## Task 4.3 — Balance + ledger display (member widget)
+
+**Type:** frontend + backend · **Effort:** L · **TRD:** PRD §5.A Point Visibility, §3.7 (embeddable SDK)
+**Progress signal:** widget renders balance + history + cash value; reflects a completed transaction <2s.
+
+**Design**
+- Embeddable web widget (B2B2C surface). Shows balance, cash equivalent ("500 pts = Rp 5,000"), ledger history. Reads tenant-scoped member API. Real-time <2s via the S3 event path (poll or push).
+- Wireframe (low-fi, locked in S0–S1) drives the API response shape — fields the widget needs define the contract.
+
+**Implementation**
+- Backend: `GET /v1/member/balance`, `GET /v1/member/ledger` (paginated), include cash-value conversion.
+- Frontend: widget consuming those endpoints; loading/empty/error states.
+
+**Testing**
+- Backend: endpoints tenant-scoped, correct cash conversion, pagination.
+- Frontend: renders balance/history; updates within 2s after a seeded transaction; empty-state.
+
+**Swagger:** `GET /v1/member/balance`, `GET /v1/member/ledger` registered with schemas.
+
+---
+
+## Task 4.4 — Redeem at checkout
+
+**Type:** frontend + backend · **Effort:** M · **TRD:** PRD §5.A Redemption, FR-1.3
+**Progress signal:** ≤3 taps from trigger to confirmation; balance validated; atomic deduction (reuses S2 guards).
+
+**Design**
+- Redeem flow at checkout reuses the atomic, double-spend-safe redemption from Sprint 2. ≤3 taps trigger→confirm. Validated balance; failed redeem deducts nothing; confirmation email/screen.
+
+**Implementation**
+- Backend: `POST /v1/member/redeem` (delegates to `RedemptionService.Create`).
+- Frontend: redeem UI in the widget — select/confirm, success + error ("Insufficient Balance") states.
+
+**Testing**
+- Backend: redeem success/insufficient/duplicate (idempotent) — already covered by S2 service tests; add member-endpoint integration.
+- Frontend: tap-count ≤3; success + insufficient-balance UX.
+
+**Swagger:** `POST /v1/member/redeem` registered.
+
+---
+
+## Task 4.5 — Operator ledger view
+
+**Type:** frontend + backend · **Effort:** M · **TRD:** PRD §5.B Ledger Visibility
+**Progress signal:** operator sees a member's tenant-scoped earn/burn history with delta/source/balance/timestamp.
+
+**Design**
+- Operator (admin surface) views per-member ledger for support/verification. Tenant-scoped. Read-only for MVP.
+
+**Implementation**
+- Backend: `GET /v1/admin/members/{id}/ledger` (tenant-scoped via S3.2).
+- Frontend: simple operator ledger table.
+
+**Testing**
+- Backend: tenant-scoped; cannot view other tenant's member (isolation test).
+- Frontend: renders entries; empty-state.
+
+**Swagger:** `GET /v1/admin/members/{id}/ledger` registered.
+
+---
+
+## Sprint 4 — Definition of Done
+
+- [ ] Full loop demoable: join → earn → see balance → redeem.
+- [ ] Member widget renders balance/ledger/cash-value; reflects txn <2s.
+- [ ] Redeem ≤3 taps, atomic, double-spend-safe.
+- [ ] OTP + confirmation emails reliable; resend works.
+- [ ] Operator ledger view live, tenant-scoped.
+- [ ] All new endpoints in Swagger; `go test -race` green; isolation tests pass.
+
+## Swagger
+
+New endpoints registered: enroll, OTP (request/verify/resend), balance, ledger, redeem, admin member-ledger. `swag init -g main.go`; CI enforces up-to-date.
+
+## Risks
+
+| Risk | L | I | Mitigation |
+|---|---|---|---|
+| Email provider undecided blocks OTP | M | High | Close Open Question before sprint start |
+| Real-time <2s not met via polling | M | Med | Use S3 event path; tune poll/push; load-test |
+| Redeem UX coupling to POS undefined | M | Med | Settle checkout integration model before 4.4 |
+
+## Dependencies
+
+S2 (redeem guards), S3 (tenant scoping + real-time events + member auth). Email provider + starting-balance policy resolved. UX wireframes from S0–S1.

--- a/docs/trd/phase-mvp/sprint-5.md
+++ b/docs/trd/phase-mvp/sprint-5.md
@@ -1,0 +1,125 @@
+# Sprint 5 — Observability + Launch Readiness
+
+> **Phase:** MVP · **Duration:** 2 weeks · **TRD anchor:** §6.2 (observability), NFR (§Phase 1), PRD §3 KPIs, §4.7 (deprecate fake dashboard)
+> **Depends on:** Sprint 4 complete.
+
+## Goal
+
+Production-ready: metrics + runtime log control, latency within budget, fake demo dashboard gone, final P0 sweep, launch sign-off. Make every MVP KPI measurable.
+
+## Why now
+
+Loop works end-to-end (S4). Now prove it's observable, fast, and clean before go-live.
+
+**Out of scope:** ClickHouse/real analytics dashboards (Phase 1), OTel full tracing (can start here, completes Phase 1).
+
+---
+
+## Task 5.1 — Metrics + runtime-configurable log level
+
+**Type:** backend · **Effort:** M · **TRD:** §6.2
+**Progress signal:** `/metrics` exposes request count/latency/error rate; log level changes without redeploy.
+
+**Design**
+- Prometheus metrics (request count, latency histogram, error rate) on key paths. zerolog level runtime-configurable (no redeploy) — closes the §6.2 + PRD observability-baseline gap.
+
+**Implementation**
+- Metrics middleware + `/metrics` endpoint. Runtime log-level setter (admin endpoint or signal/config reload).
+
+**Testing**
+- `/metrics` returns expected series after traffic.
+- Flip log level at runtime → verbosity changes, no restart.
+
+**Swagger:** `/metrics` documented (or noted as Prometheus scrape, non-`/v1`). Log-level admin endpoint registered if HTTP.
+
+---
+
+## Task 5.2 — Latency hardening
+
+**Type:** backend · **Effort:** M · **TRD:** NFR §Phase 1, PRD §3 (Real-time)
+**Progress signal:** earn-to-visible <2s p99; point-award API <300ms p99 under load.
+
+**Design**
+- Validate NFR targets: API p99 <300ms, earn-to-visible <2s. Profile hot paths (rule eval, ledger insert, balance read). Load test toward MVP 500 TPS (headroom to 1,000).
+
+**Implementation**
+- Profile + tune queries/indexes/cache; fix N+1 or slow rule eval found.
+
+**Testing**
+- Load test (k6/vegeta): assert p99 budgets at target TPS; capture report.
+
+---
+
+## Task 5.3 — Remove fake demo dashboard
+
+**Type:** frontend · **Effort:** S · **TRD:** §4.7 (deprecate), PRD §4
+**Progress signal:** no screen shows template/demo "Sales" data; honest empty state instead.
+
+**Design**
+- Fake "Sales" template dashboard removed, not replaced (real analytics is Phase 1). Honest empty state or redirect to the member/operator surfaces from S4.
+
+**Implementation**
+- Delete demo dashboard + sample data; replace landing with real surface or empty state.
+
+**Testing**
+- No template data renders anywhere (UI smoke + grep for sample fixtures).
+
+---
+
+## Task 5.4 — Close MVP Open Questions (policy)
+
+**Type:** product/backend · **Effort:** S · **TRD:** PRD §10, §6.3 (double-entry audit)
+**Progress signal:** points-liability accounting stance + starting-balance policy documented + implemented.
+
+**Design**
+- Resolve: points-liability accounting stance (audit-trail expectation per §6.3 — double-entry built now), starting-balance policy. Email provider already settled in S4.
+
+**Implementation**
+- Encode policies in config; ensure ledger audit trail satisfies the agreed accounting stance.
+
+**Testing**
+- Config drives starting balance; audit trail export reconciles earn/burn.
+
+---
+
+## Task 5.5 — Launch-readiness checklist
+
+**Type:** infra/backend · **Effort:** M · **TRD:** PRD §3 (all KPIs), §6.2 (SLO before Done)
+**Progress signal:** signed checklist — 0 known P0, `-race` green, isolation tests pass, runbook exists, SLO dashboard live.
+
+**Design**
+- Gate go-live on: 0 known P0 (re-sweep S0 items), `go test -race ./...` green, tenant isolation tests pass, KPIs instrumented (activation, correctness, latency, safety, isolation), liveness/readiness probes (`/healthz/live`, `/healthz/ready`), runbook + rollback plan, SLO dashboard live (§6.2 — no phase Done without it).
+
+**Implementation**
+- Split health probes; assemble dashboard from 5.1 metrics; write runbook/ADR (bus-factor mitigation, §8).
+
+**Testing**
+- Full `go test -race ./...` green; isolation suite green; probes respond; dashboard shows live KPIs.
+
+**Swagger:** `/healthz/live`, `/healthz/ready` documented.
+
+---
+
+## Sprint 5 — Definition of Done
+
+- [ ] `/metrics` live; log level runtime-configurable.
+- [ ] p99 budgets met under load (earn-visible <2s, API <300ms) at target TPS.
+- [ ] Fake dashboard removed; no demo data anywhere.
+- [ ] Open Questions (accounting, starting-balance) closed + encoded.
+- [ ] Launch checklist signed: 0 P0, `-race` green, isolation green, probes + runbook + SLO dashboard.
+- [ ] All MVP §3 KPIs instrumented and visible.
+
+## Swagger
+
+`/metrics`, `/healthz/live`, `/healthz/ready`, log-level admin endpoint (if HTTP) registered. Final `swag init -g main.go`; CI enforces up-to-date as a launch gate.
+
+## Risks
+
+| Risk | L | I | Mitigation |
+|---|---|---|---|
+| Latency target missed at 500 TPS | M | High | Profile early; index/cache tune; 2× headroom load test |
+| Single-developer bus factor | H | High | Runbooks + ADRs (TRD §8); small reviewed changes |
+
+## Dependencies
+
+S1–S4 complete. Closes the MVP. Real analytics dashboard + ClickHouse + OTel-complete + Temporal expansion → Phase 1.


### PR DESCRIPTION
## Summary
- **docs/trd/phase-mvp/** — per-sprint technical dev plans (Sprint 0–5) for the MVP earn/burn loop. Each task carries Design / Implementation / Testing, an observable progress signal, Swagger registration note, and estimation (effort → size/SP/confidence). README index with sequencing + DoD.
- **.claude/skills/github-issue/** — skill that turns `docs/trd/<phase>/sprint-*.md` into a tracked GitHub backlog: Epic (sprint) → User Story (task), scrum/kanban convention, estimation + tagging + Project board fields. Reuses github-pr project machinery + sdlc draft-don't-execute principle.
- **CLAUDE.md** — wire the github-issue skill into the SDLC section.

Docs + tooling only. No application code, no migrations.

## Risk
Low. Documentation and a Claude skill; no runtime, build, or schema impact.

## Rollback
Revert this PR — removes the docs/skill files and the CLAUDE.md pointer.

## Test plan
- [x] Markdown renders; sprint files cross-link via README
- [x] Skill follows existing github-pr/sdlc conventions (labels, project fields, draft-only)
- [ ] N/A — no code, `go test` unaffected

Note: `notes.md` (scratch high-level plan) intentionally excluded from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)